### PR TITLE
AdminServer is now the only one to send_webhook

### DIFF
--- a/aries_cloudagent/admin/base_server.py
+++ b/aries_cloudagent/admin/base_server.py
@@ -2,9 +2,6 @@
 
 
 from abc import ABC, abstractmethod
-from typing import Sequence
-
-from ..core.profile import Profile
 
 
 class BaseAdminServer(ABC):
@@ -23,20 +20,3 @@ class BaseAdminServer(ABC):
     @abstractmethod
     async def stop(self) -> None:
         """Stop the webserver."""
-
-    @abstractmethod
-    def add_webhook_target(
-        self,
-        target_url: str,
-        topic_filter: Sequence[str] = None,
-        max_attempts: int = None,
-    ):
-        """Add a webhook target."""
-
-    @abstractmethod
-    def remove_webhook_target(self, target_url: str):
-        """Remove a webhook target."""
-
-    @abstractmethod
-    async def send_webhook(self, profile: Profile, topic: str, payload: dict):
-        """Add a webhook to the queue, to send to all registered targets."""

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -43,6 +43,7 @@ LOGGER = logging.getLogger(__name__)
 
 EVENT_PATTERN_ACAPY = re.compile("^acapy::(.*)$")
 EVENT_PATTERN_WEBHOOK = re.compile("^acapy::webhook::(.*)$")
+EVENT_PATTERN_RECORD = re.compile("^acapy::record::(.*)::(.*)$")
 
 EVENT_WEBHOOK_MAPPING = {
     "acapy::basicmessage::received": "basicmessages",
@@ -708,6 +709,11 @@ class AdminServer(BaseAdminServer):
 
     async def __on_acapy_event(self, profile: Profile, event: Event):
         webhook_topic = EVENT_WEBHOOK_MAPPING.get(event.topic)
+
+        if not webhook_topic:
+            match = EVENT_PATTERN_RECORD.search(event.topic)
+            webhook_topic = match.group(1) if match else None
+
         if not webhook_topic:
             match = EVENT_PATTERN_WEBHOOK.search(event.topic)
             webhook_topic = match.group(1) if match else None

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -41,7 +41,6 @@ from .request_context import AdminRequestContext
 
 LOGGER = logging.getLogger(__name__)
 
-EVENT_PATTERN_ACAPY = re.compile("^acapy::(.*)$")
 EVENT_PATTERN_WEBHOOK = re.compile("^acapy::webhook::(.*)$")
 EVENT_PATTERN_RECORD = re.compile("^acapy::record::(.*)::(.*)$")
 
@@ -417,7 +416,16 @@ class AdminServer(BaseAdminServer):
 
         event_bus = self.context.inject(EventBus, required=False)
         if event_bus:
-            event_bus.subscribe(EVENT_PATTERN_ACAPY, self.__on_acapy_event)
+            event_bus.subscribe(EVENT_PATTERN_WEBHOOK, self.__on_webhook_event)
+            event_bus.subscribe(EVENT_PATTERN_RECORD, self.__on_record_event)
+
+            for event_topic, webhook_topic in EVENT_WEBHOOK_MAPPING.items():
+                event_bus.subscribe(
+                    re.compile(re.escape(event_topic)),
+                    lambda profile, event: self.send_webhook(
+                        profile, webhook_topic, event.payload
+                    ),
+                )
 
         # order tags alphabetically, parameters deterministically and pythonically
         swagger_dict = self.app._state["swagger_dict"]
@@ -707,17 +715,15 @@ class AdminServer(BaseAdminServer):
 
         return ws
 
-    async def __on_acapy_event(self, profile: Profile, event: Event):
-        webhook_topic = EVENT_WEBHOOK_MAPPING.get(event.topic)
+    async def __on_webhook_event(self, profile: Profile, event: Event):
+        match = EVENT_PATTERN_WEBHOOK.search(event.topic)
+        webhook_topic = match.group(1) if match else None
+        if webhook_topic:
+            await self.send_webhook(profile, webhook_topic, event.payload)
 
-        if not webhook_topic:
-            match = EVENT_PATTERN_RECORD.search(event.topic)
-            webhook_topic = match.group(1) if match else None
-
-        if not webhook_topic:
-            match = EVENT_PATTERN_WEBHOOK.search(event.topic)
-            webhook_topic = match.group(1) if match else None
-
+    async def __on_record_event(self, profile: Profile, event: Event):
+        match = EVENT_PATTERN_RECORD.search(event.topic)
+        webhook_topic = match.group(1) if match else None
         if webhook_topic:
             await self.send_webhook(profile, webhook_topic, event.payload)
 

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -5,6 +5,7 @@ import logging
 import re
 from typing import Callable, Coroutine
 import uuid
+import warnings
 
 from aiohttp import web
 from aiohttp_apispec import (
@@ -99,6 +100,20 @@ class AdminResponder(BaseResponder):
             message: The `OutboundMessage` to be sent
         """
         await self._send(self._profile, message)
+
+    async def send_webhook(self, topic: str, payload: dict):
+        """
+        Dispatch a webhook. DEPRECATED: use the event bus instead.
+
+        Args:
+            topic: the webhook topic identifier
+            payload: the webhook payload value
+        """
+        warnings.warn(
+            "responder.send_webhook is deprecated; please use the event bus instead.",
+            DeprecationWarning,
+        )
+        await self._profile.notify("acapy::webhook::" + topic, payload)
 
 
 @web.middleware

--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -141,7 +141,7 @@ class ConnRecord(BaseRecord):
             return self is ConnRecord.State.get(other)
 
     RECORD_ID_NAME = "connection_id"
-    WEBHOOK_TOPIC = "connections"
+    RECORD_TOPIC = "connections"
     LOG_STATE_FLAG = "debug.connections"
     TAG_NAMES = {"my_did", "their_did", "request_id", "invitation_key"}
 

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -138,10 +138,6 @@ class Conductor:
                     self.dispatcher.task_queue,
                     self.get_stats,
                 )
-                webhook_urls = context.settings.get("admin.webhook_urls")
-                if webhook_urls:
-                    for url in webhook_urls:
-                        self.admin_server.add_webhook_target(url)
                 context.injector.bind_instance(BaseAdminServer, self.admin_server)
                 if "http" not in self.outbound_transport_manager.registered_schemes:
                     self.outbound_transport_manager.register("http")
@@ -200,7 +196,6 @@ class Conductor:
             responder = AdminResponder(
                 self.root_profile,
                 self.admin_server.outbound_message_router,
-                self.admin_server.send_webhook,
             )
             context.injector.bind_instance(BaseResponder, responder)
 
@@ -391,7 +386,6 @@ class Conductor:
                 profile,
                 message,
                 self.outbound_message_router,
-                self.admin_server and self.admin_server.send_webhook,
                 lambda completed: self.dispatch_complete(message, completed),
             )
         except (LedgerConfigError, LedgerTransactionError) as e:

--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import os
 from typing import Callable, Coroutine, Union
+import warnings
 
 from aiohttp.web import HTTPException
 
@@ -289,3 +290,17 @@ class DispatcherResponder(BaseResponder):
             message: The `OutboundMessage` to be sent
         """
         await self._send(self._context.profile, message, self._inbound_message)
+
+    async def send_webhook(self, topic: str, payload: dict):
+        """
+        Dispatch a webhook. DEPRECATED: use the event bus instead.
+
+        Args:
+            topic: the webhook topic identifier
+            payload: the webhook payload value
+        """
+        warnings.warn(
+            "responder.send_webhook is deprecated; please use the event bus instead.",
+            DeprecationWarning,
+        )
+        await self._context.profile.notify("acapy::webhook::" + topic, payload)

--- a/aries_cloudagent/core/event_bus.py
+++ b/aries_cloudagent/core/event_bus.py
@@ -1,10 +1,13 @@
 """A simple event bus."""
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..core.profile import Profile
+
 import logging
 from itertools import chain
 from typing import Any, Callable, Dict, Pattern, Sequence
-
-from ..core.profile import Profile
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,7 +48,7 @@ class EventBus:
         """Initialize Event Bus."""
         self.topic_patterns_to_subscribers: Dict[Pattern, Sequence[Callable]] = {}
 
-    async def notify(self, profile: Profile, event: Event):
+    async def notify(self, profile: "Profile", event: Event):
         """Notify subscribers of event.
 
         Args:
@@ -103,3 +106,16 @@ class EventBus:
             if not self.topic_patterns_to_subscribers[pattern]:
                 del self.topic_patterns_to_subscribers[pattern]
             LOGGER.debug("Unsubscribed: topic %s, processor %s", pattern, processor)
+
+
+class MockEventBus(EventBus):
+    """A mock EventBus for testing."""
+
+    def __init__(self):
+        """Initialize MockEventBus."""
+        super().__init__()
+        self.events = []
+
+    async def notify(self, profile: "Profile", event: Event):
+        """Append the event to MockEventBus.events."""
+        self.events.append((profile, event))

--- a/aries_cloudagent/core/event_bus.py
+++ b/aries_cloudagent/core/event_bus.py
@@ -1,13 +1,11 @@
 """A simple event bus."""
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from ..core.profile import Profile
-
 import logging
 from itertools import chain
-from typing import Any, Callable, Dict, Pattern, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Dict, Pattern, Sequence
+
+if TYPE_CHECKING:  # To avoid circular import error
+    from .profile import Profile
 
 LOGGER = logging.getLogger(__name__)
 

--- a/aries_cloudagent/core/profile.py
+++ b/aries_cloudagent/core/profile.py
@@ -5,6 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Mapping, Optional, Type
 
+from .event_bus import EventBus, Event
 from ..config.base import InjectionError
 from ..config.injector import BaseInjector, InjectType
 from ..config.injection_context import InjectionContext
@@ -98,6 +99,12 @@ class Profile(ABC):
 
     async def remove(self):
         """Remove the profile."""
+
+    async def notify(self, topic: str, payload: Any):
+        """Signal an event."""
+        event_bus = self.inject(EventBus, required=False)
+        if event_bus:
+            await event_bus.notify(self, Event(topic, payload))
 
     def __repr__(self) -> str:
         """Get a human readable string."""

--- a/aries_cloudagent/core/tests/test_conductor.py
+++ b/aries_cloudagent/core/tests/test_conductor.py
@@ -240,8 +240,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             assert mock_dispatch_q.call_args[0][0] is conductor.context
             assert mock_dispatch_q.call_args[0][1] is message
             assert mock_dispatch_q.call_args[0][2] == conductor.outbound_message_router
-            assert mock_dispatch_q.call_args[0][3] is None  # admin webhook router
-            assert callable(mock_dispatch_q.call_args[0][4])
+            assert callable(mock_dispatch_q.call_args[0][3])
 
     async def test_inbound_message_handler_ledger_x(self):
         builder: ContextBuilder = StubContextBuilder(self.test_settings_admin)

--- a/aries_cloudagent/core/tests/test_dispatcher.py
+++ b/aries_cloudagent/core/tests/test_dispatcher.py
@@ -351,24 +351,6 @@ class TestDispatcher(AsyncTestCase):
         )
         dispatcher.log_task(mock_task)
 
-    async def test_create_outbound_send_webhook(self):
-        profile = make_profile()
-        context = RequestContext(profile)
-        context.message_receipt = async_mock.MagicMock(in_time=datetime_now())
-        context.update_settings({"timing.enabled": True})
-        message = StubAgentMessage()
-        responder = test_module.DispatcherResponder(
-            context, message, None, async_mock.CoroutineMock()
-        )
-        result = await responder.create_outbound(message)
-        assert json.loads(result.payload)["@type"] == DIDCommPrefix.qualify_current(
-            StubAgentMessage.Meta.message_type
-        )
-        await responder.send_webhook("topic", "payload")
-
-        context.default_endpoint = "http://agent.ca"
-        assert context.default_endpoint == "http://agent.ca"
-
     async def test_create_send_outbound(self):
         message = StubAgentMessage()
         responder = MockResponder()
@@ -380,9 +362,7 @@ class TestDispatcher(AsyncTestCase):
         profile = make_profile()
         context = RequestContext(profile)
         message = b"abc123xyz7890000"
-        responder = test_module.DispatcherResponder(
-            context, message, None, async_mock.CoroutineMock()
-        )
+        responder = test_module.DispatcherResponder(context, message, None)
         with async_mock.patch.object(
             responder, "send_outbound", async_mock.CoroutineMock()
         ) as mock_send_outbound:

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -5,7 +5,7 @@ import sys
 import uuid
 
 from datetime import datetime
-from typing import Any, Mapping, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from marshmallow import fields
 
@@ -69,7 +69,7 @@ class BaseRecord(BaseModel):
     DEFAULT_CACHE_TTL = 60
     RECORD_ID_NAME = "id"
     RECORD_TYPE = None
-    WEBHOOK_TOPIC = None
+    RECORD_TOPIC: Optional[str] = None
     LOG_STATE_FLAG = None
     TAG_NAMES = {"state"}
 
@@ -301,7 +301,7 @@ class BaseRecord(BaseModel):
         reason: str = None,
         log_params: Mapping[str, Any] = None,
         log_override: bool = False,
-        webhook: bool = None,
+        event: bool = None,
     ) -> str:
         """Persist the record to storage.
 
@@ -309,7 +309,7 @@ class BaseRecord(BaseModel):
             session: The profile session to use
             reason: A reason to add to the log
             log_params: Additional parameters to log
-            webhook: Flag to override whether the webhook is sent
+            event: Flag to override whether the event is sent
         """
         new_record = None
         log_reason = reason or ("Updated record" if self._id else "Created record")
@@ -335,7 +335,7 @@ class BaseRecord(BaseModel):
                 log_reason, params, override=log_override, settings=session.settings
             )
 
-        await self.post_save(session, new_record, self._last_state, webhook)
+        await self.post_save(session, new_record, self._last_state, event)
         self._last_state = self.state
 
         return self._id
@@ -344,8 +344,8 @@ class BaseRecord(BaseModel):
         self,
         session: ProfileSession,
         new_record: bool,
-        last_state: str,
-        webhook: bool = None,
+        last_state: Optional[str],
+        event: bool = None,
     ):
         """Perform post-save actions.
 
@@ -353,15 +353,12 @@ class BaseRecord(BaseModel):
             session: The profile session to use
             new_record: Flag indicating if the record was just created
             last_state: The previous state value
-            webhook: Adjust whether the webhook is called
+            event: Flag to override whether the event is sent
         """
-        webhook_topic = self.webhook_topic
-        if webhook is None:
-            webhook = bool(webhook_topic) and (new_record or (last_state != self.state))
-        if webhook:
-            await self.send_webhook(
-                session, self.webhook_payload, topic=self.webhook_topic
-            )
+        if event is None:
+            event = new_record or (last_state != self.state)
+        if event:
+            await self.emit_event(session, self.serialize())
 
     async def delete_record(self, session: ProfileSession):
         """Remove the stored record.
@@ -374,34 +371,20 @@ class BaseRecord(BaseModel):
             await storage.delete_record(self.storage_record)
         # FIXME - update state and send webhook?
 
-    @property
-    def webhook_payload(self):
-        """Return a JSON-serialized version of the record for the webhook."""
-        return self.serialize()
-
-    @property
-    def webhook_topic(self):
-        """Return the webhook topic value."""
-        return self.WEBHOOK_TOPIC
-
-    async def send_webhook(
-        self, session: ProfileSession, payload: Any, topic: str = None
-    ):
-        """Send a standard webhook.
+    async def emit_event(self, session: ProfileSession, payload: Any):
+        """Emit an event.
 
         Args:
             session: The profile session to use
-            payload: The webhook payload
-            topic: The webhook topic, defaulting to WEBHOOK_TOPIC
+            payload: The event payload
         """
-        if not payload:
-            return
-        if not topic:
-            topic = self.webhook_topic
-            if not topic:
-                return
 
-        await session.profile.notify("acapy::webhook::" + topic, payload)
+        if not self.RECORD_TOPIC or not self.state or not payload:
+            return
+
+        await session.profile.notify(
+            f"acapy::record::{self.RECORD_TOPIC}::{self.state}", payload
+        )
 
     @classmethod
     def log_state(

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -16,7 +16,6 @@ from ...storage.base import BaseStorage, StorageDuplicateError, StorageNotFoundE
 from ...storage.record import StorageRecord
 
 from .base import BaseModel, BaseModelSchema
-from ..responder import BaseResponder
 from ..util import datetime_to_str, time_now
 from ..valid import INDY_ISO8601_DATETIME
 
@@ -401,9 +400,8 @@ class BaseRecord(BaseModel):
             topic = self.webhook_topic
             if not topic:
                 return
-        responder = session.inject(BaseResponder, required=False)
-        if responder:
-            await responder.send_webhook(topic, payload)
+
+        await session.profile.notify("acapy::webhook::" + topic, payload)
 
     @classmethod
     def log_state(

--- a/aries_cloudagent/messaging/models/tests/test_base_record.py
+++ b/aries_cloudagent/messaging/models/tests/test_base_record.py
@@ -86,7 +86,7 @@ class TestBaseRecord(AsyncTestCase):
         with async_mock.patch.object(
             record, "post_save", async_mock.CoroutineMock()
         ) as post_save:
-            await record.save(session, reason="reason", webhook=True)
+            await record.save(session, reason="reason", event=True)
             post_save.assert_called_once_with(session, True, None, True)
         mock_storage.add_record.assert_called_once()
 
@@ -102,7 +102,7 @@ class TestBaseRecord(AsyncTestCase):
         with async_mock.patch.object(
             record, "post_save", async_mock.CoroutineMock()
         ) as post_save:
-            await record.save(session, reason="reason", webhook=False)
+            await record.save(session, reason="reason", event=False)
             post_save.assert_called_once_with(session, False, last_state, False)
         mock_storage.update_record.assert_called_once()
 
@@ -254,18 +254,21 @@ class TestBaseRecord(AsyncTestCase):
         record.log_state("state", settings=None)
         mock_print.assert_not_called()
 
-    async def test_webhook(self):
+    async def test_emit_event(self):
         session = InMemoryProfile.test_session()
         mock_event_bus = MockEventBus()
         session.profile.context.injector.bind_instance(EventBus, mock_event_bus)
         record = BaseRecordImpl()
         payload = {"test": "payload"}
-        topic = "topic"
-        await record.send_webhook(session, None, None)  # cover short circuit
-        await record.send_webhook(session, "hello", None)  # cover short circuit
-        await record.send_webhook(session, payload, topic=topic)
+        await record.emit_event(session, None)  # cover short circuit
+        await record.emit_event(session, payload)  # cover short circuit
+        record.RECORD_TOPIC = "topic"
+        await record.emit_event(session, payload)  # cover short circuit
+        assert mock_event_bus.events == []
+        record.state = "test_state"
+        await record.emit_event(session, payload)
         assert mock_event_bus.events == [
-            (session.profile, Event("acapy::webhook::topic", payload))
+            (session.profile, Event("acapy::record::topic::test_state", payload))
         ]
 
     async def test_tag_prefix(self):

--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -113,16 +113,6 @@ class BaseResponder(ABC):
             message: The `OutboundMessage` to be sent
         """
 
-    @abstractmethod
-    async def send_webhook(self, topic: str, payload: dict):
-        """
-        Dispatch a webhook.
-
-        Args:
-            topic: the webhook topic identifier
-            payload: the webhook payload value
-        """
-
 
 class MockResponder(BaseResponder):
     """Mock responder implementation for use by tests."""
@@ -130,7 +120,6 @@ class MockResponder(BaseResponder):
     def __init__(self):
         """Initialize the mock responder."""
         self.messages = []
-        self.webhooks = []
 
     async def send(self, message: Union[AgentMessage, str, bytes], **kwargs):
         """Convert a message to an OutboundMessage and send it."""
@@ -143,7 +132,3 @@ class MockResponder(BaseResponder):
     async def send_outbound(self, message: OutboundMessage):
         """Send an outbound message."""
         self.messages.append((message, None))
-
-    async def send_webhook(self, topic: str, payload: dict):
-        """Send an outbound message."""
-        self.webhooks.append((topic, payload))

--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -113,6 +113,16 @@ class BaseResponder(ABC):
             message: The `OutboundMessage` to be sent
         """
 
+    @abstractmethod
+    async def send_webhook(self, topic: str, payload: dict):
+        """
+        Dispatch a webhook. DEPRECATED: use the event bus instead.
+
+        Args:
+            topic: the webhook topic identifier
+            payload: the webhook payload value
+        """
+
 
 class MockResponder(BaseResponder):
     """Mock responder implementation for use by tests."""
@@ -132,3 +142,9 @@ class MockResponder(BaseResponder):
     async def send_outbound(self, message: OutboundMessage):
         """Send an outbound message."""
         self.messages.append((message, None))
+
+    async def send_webhook(self, topic: str, payload: dict):
+        """Send an outbound message."""
+        raise Exception(
+            "responder.send_webhook is deprecated; please use the event bus instead."
+        )

--- a/aries_cloudagent/protocols/actionmenu/v1_0/base_service.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/base_service.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 
 from ....config.injection_context import InjectionContext
 from ....connections.models.conn_record import ConnRecord
+from ....core.profile import Profile
 from ....messaging.agent_message import AgentMessage
 
 from .messages.menu import Menu
@@ -28,12 +29,16 @@ class BaseMenuService(ABC):
 
     @abstractmethod
     async def get_active_menu(
-        self, connection: ConnRecord = None, thread_id: str = None
+        self,
+        profile: Profile,
+        connection: ConnRecord = None,
+        thread_id: str = None,
     ) -> Menu:
         """
         Render the current menu.
 
         Args:
+            profile: The profile
             connection: The active connection record
             thread_id: The thread identifier from the requesting message.
         """
@@ -41,6 +46,7 @@ class BaseMenuService(ABC):
     @abstractmethod
     async def perform_menu_action(
         self,
+        profile: Profile,
         action_name: str,
         action_params: dict,
         connection: ConnRecord = None,
@@ -50,6 +56,7 @@ class BaseMenuService(ABC):
         Perform an action defined by the active menu.
 
         Args:
+            profile: The profile
             action_name: The unique name of the action being performed
             action_params: A collection of parameters for the action
             connection: The active connection record

--- a/aries_cloudagent/protocols/actionmenu/v1_0/driver_service.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/driver_service.py
@@ -3,8 +3,8 @@
 import logging
 
 from ....connections.models.conn_record import ConnRecord
+from ....core.profile import Profile
 from ....messaging.agent_message import AgentMessage
-from ....messaging.responder import BaseResponder
 
 from .base_service import BaseMenuService
 from .messages.menu import Menu
@@ -16,17 +16,21 @@ class DriverMenuService(BaseMenuService):
     """Driver-based action menu service."""
 
     async def get_active_menu(
-        self, connection: ConnRecord = None, thread_id: str = None
+        self,
+        profile: Profile,
+        connection: ConnRecord = None,
+        thread_id: str = None,
     ) -> Menu:
         """
         Render the current menu.
 
         Args:
+            profile: The profile
             connection: The active connection record
             thread_id: The thread identifier from the requesting message.
         """
-        await self.send_webhook(
-            "get-active-menu",
+        await profile.notify(
+            "acapy::webhook::get-active-menu",
             {
                 "connection_id": connection and connection.connection_id,
                 "thread_id": thread_id,
@@ -36,6 +40,7 @@ class DriverMenuService(BaseMenuService):
 
     async def perform_menu_action(
         self,
+        profile: Profile,
         action_name: str,
         action_params: dict,
         connection: ConnRecord = None,
@@ -45,13 +50,14 @@ class DriverMenuService(BaseMenuService):
         Perform an action defined by the active menu.
 
         Args:
+            profile: The profile
             action_name: The unique name of the action being performed
             action_params: A collection of parameters for the action
             connection: The active connection record
             thread_id: The thread identifier from the requesting message.
         """
-        await self.send_webhook(
-            "perform-menu-action",
+        await profile.notify(
+            "acapy::webhook::perform-menu-action",
             {
                 "connection_id": connection and connection.connection_id,
                 "thread_id": thread_id,
@@ -60,9 +66,3 @@ class DriverMenuService(BaseMenuService):
             },
         )
         return None
-
-    async def send_webhook(self, topic: str, payload: dict):
-        """Dispatch a webhook through the registered responder."""
-        responder = self._context.inject(BaseResponder, required=False)
-        if responder:
-            await responder.send_webhook(topic, payload)

--- a/aries_cloudagent/protocols/actionmenu/v1_0/driver_service.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/driver_service.py
@@ -30,7 +30,7 @@ class DriverMenuService(BaseMenuService):
             thread_id: The thread identifier from the requesting message.
         """
         await profile.notify(
-            "acapy::webhook::get-active-menu",
+            "acapy::actionmenu::get-active-menu",
             {
                 "connection_id": connection and connection.connection_id,
                 "thread_id": thread_id,
@@ -57,7 +57,7 @@ class DriverMenuService(BaseMenuService):
             thread_id: The thread identifier from the requesting message.
         """
         await profile.notify(
-            "acapy::webhook::perform-menu-action",
+            "acapy::actionmenu::perform-menu-action",
             {
                 "connection_id": connection and connection.connection_id,
                 "thread_id": thread_id,

--- a/aries_cloudagent/protocols/actionmenu/v1_0/handlers/menu_request_handler.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/handlers/menu_request_handler.py
@@ -29,7 +29,9 @@ class MenuRequestHandler(BaseHandler):
         service: BaseMenuService = context.inject(BaseMenuService, required=False)
         if service:
             menu = await service.get_active_menu(
-                context.connection_record, context.message._thread_id
+                context.profile,
+                context.connection_record,
+                context.message._thread_id,
             )
             if menu:
                 await responder.send_reply(menu)

--- a/aries_cloudagent/protocols/actionmenu/v1_0/handlers/perform_handler.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/handlers/perform_handler.py
@@ -29,6 +29,7 @@ class PerformHandler(BaseHandler):
         service: BaseMenuService = context.inject(BaseMenuService, required=False)
         if service:
             reply = await service.perform_menu_action(
+                context.profile,
                 context.message.name,
                 context.message.params or {},
                 context.connection_record,

--- a/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_service.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_service.py
@@ -31,7 +31,7 @@ class TestActionMenuService(AsyncTestCase):
 
         assert len(mock_event_bus.events) == 1
         (_, event) = mock_event_bus.events[0]
-        assert event.topic == "acapy::webhook::get-active-menu"
+        assert event.topic == "acapy::actionmenu::get-active-menu"
         assert event.payload == {
             "connection_id": connection.connection_id,
             "thread_id": thread_id,
@@ -61,7 +61,7 @@ class TestActionMenuService(AsyncTestCase):
 
         assert len(mock_event_bus.events) == 1
         (_, event) = mock_event_bus.events[0]
-        assert event.topic == "acapy::webhook::perform-menu-action"
+        assert event.topic == "acapy::actionmenu::perform-menu-action"
         assert event.payload == {
             "connection_id": connection.connection_id,
             "thread_id": thread_id,

--- a/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_service.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_service.py
@@ -1,9 +1,9 @@
 from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 
+from .....core.event_bus import EventBus, MockEventBus
 from .....core.in_memory import InMemoryProfile
 from .....messaging.request_context import RequestContext
-from .....messaging.responder import MockResponder
 
 from .. import driver_service as test_module
 
@@ -14,8 +14,8 @@ class TestActionMenuService(AsyncTestCase):
         self.context = RequestContext(self.session.profile)
 
     async def test_get_active_menu(self):
-        self.responder = MockResponder()
-        self.context.injector.bind_instance(test_module.BaseResponder, self.responder)
+        mock_event_bus = MockEventBus()
+        self.context.profile.context.injector.bind_instance(EventBus, mock_event_bus)
 
         self.menu_service = await (
             test_module.DriverMenuService.service_handler()(self.context)
@@ -25,20 +25,21 @@ class TestActionMenuService(AsyncTestCase):
         connection.connection_id = "connid"
         thread_id = "thid"
 
-        await self.menu_service.get_active_menu(connection, thread_id)
+        await self.menu_service.get_active_menu(
+            self.context.profile, connection, thread_id
+        )
 
-        webhooks = self.responder.webhooks
-        assert len(webhooks) == 1
-        (result, target) = webhooks[0]
-        assert result == "get-active-menu"
-        assert target == {
+        assert len(mock_event_bus.events) == 1
+        (_, event) = mock_event_bus.events[0]
+        assert event.topic == "acapy::webhook::get-active-menu"
+        assert event.payload == {
             "connection_id": connection.connection_id,
             "thread_id": thread_id,
         }
 
     async def test_perform_menu_action(self):
-        self.responder = MockResponder()
-        self.context.injector.bind_instance(test_module.BaseResponder, self.responder)
+        mock_event_bus = MockEventBus()
+        self.context.profile.context.injector.bind_instance(EventBus, mock_event_bus)
 
         self.menu_service = await (
             test_module.DriverMenuService.service_handler()(self.context)
@@ -51,14 +52,17 @@ class TestActionMenuService(AsyncTestCase):
         thread_id = "thid"
 
         await self.menu_service.perform_menu_action(
-            action_name, action_params, connection, thread_id
+            self.context.profile,
+            action_name,
+            action_params,
+            connection,
+            thread_id,
         )
 
-        webhooks = self.responder.webhooks
-        assert len(webhooks) == 1
-        (result, target) = webhooks[0]
-        assert result == "perform-menu-action"
-        assert target == {
+        assert len(mock_event_bus.events) == 1
+        (_, event) = mock_event_bus.events[0]
+        assert event.topic == "acapy::webhook::perform-menu-action"
+        assert event.payload == {
             "connection_id": connection.connection_id,
             "thread_id": thread_id,
             "action_name": action_name,

--- a/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_util.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_util.py
@@ -1,7 +1,7 @@
 from asynctest import TestCase as AsyncTestCase
 
+from .....core.event_bus import EventBus, MockEventBus
 from .....admin.request_context import AdminRequestContext
-from .....messaging.responder import MockResponder
 
 from .. import util as test_module
 from ..models.menu_form_param import MenuFormParam
@@ -13,8 +13,8 @@ class TestActionMenuUtil(AsyncTestCase):
     async def test_save_retrieve_delete_connection_menu(self):
         context = AdminRequestContext.test_context()
 
-        responder = MockResponder()
-        context.injector.bind_instance(test_module.BaseResponder, responder)
+        mock_event_bus = MockEventBus()
+        context.profile.context.injector.bind_instance(EventBus, mock_event_bus)
 
         menu = test_module.Menu(
             title="title",
@@ -50,13 +50,12 @@ class TestActionMenuUtil(AsyncTestCase):
         for i in range(2):  # once to add, once to update
             await test_module.save_connection_menu(menu, connection_id, context)
 
-            webhooks = responder.webhooks
-            assert len(webhooks) == 1
-            (result, target) = webhooks[0]
-            assert result == "actionmenu"
-            assert target["connection_id"] == connection_id
-            assert target["menu"] == menu.serialize()
-            responder.webhooks.clear()
+            assert len(mock_event_bus.events) == 1
+            (_, event) = mock_event_bus.events[0]
+            assert event.topic == "acapy::webhook::actionmenu"
+            assert event.payload["connection_id"] == connection_id
+            assert event.payload["menu"] == menu.serialize()
+            mock_event_bus.events.clear()
 
         # retrieve connection menu
         assert (
@@ -66,12 +65,11 @@ class TestActionMenuUtil(AsyncTestCase):
         # delete connection menu
         await test_module.save_connection_menu(None, connection_id, context)
 
-        webhooks = responder.webhooks
-        assert len(webhooks) == 1
-        (result, target) = webhooks[0]
-        assert result == "actionmenu"
-        assert target == {"connection_id": connection_id, "menu": None}
-        responder.webhooks.clear()
+        assert len(mock_event_bus.events) == 1
+        (_, event) = mock_event_bus.events[0]
+        assert event.topic == "acapy::webhook::actionmenu"
+        assert event.payload == {"connection_id": connection_id, "menu": None}
+        mock_event_bus.events.clear()
 
         # retrieve no menu
         assert (

--- a/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_util.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_util.py
@@ -52,7 +52,7 @@ class TestActionMenuUtil(AsyncTestCase):
 
             assert len(mock_event_bus.events) == 1
             (_, event) = mock_event_bus.events[0]
-            assert event.topic == "acapy::webhook::actionmenu"
+            assert event.topic == "acapy::actionmenu::received"
             assert event.payload["connection_id"] == connection_id
             assert event.payload["menu"] == menu.serialize()
             mock_event_bus.events.clear()
@@ -67,7 +67,7 @@ class TestActionMenuUtil(AsyncTestCase):
 
         assert len(mock_event_bus.events) == 1
         (_, event) = mock_event_bus.events[0]
-        assert event.topic == "acapy::webhook::actionmenu"
+        assert event.topic == "acapy::actionmenu::received"
         assert event.payload == {"connection_id": connection_id, "menu": None}
         mock_event_bus.events.clear()
 

--- a/aries_cloudagent/protocols/actionmenu/v1_0/util.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/util.py
@@ -1,7 +1,6 @@
 """Action menu utility methods."""
 
 from ....admin.request_context import AdminRequestContext
-from ....messaging.responder import BaseResponder
 from ....storage.base import (
     BaseStorage,
     StorageRecord,
@@ -54,12 +53,10 @@ async def save_connection_menu(
             else:
                 await storage.delete_record(record)
 
-    responder = context.inject(BaseResponder, required=False)
-    if responder:
-        await responder.send_webhook(
-            "actionmenu",
-            {
-                "connection_id": connection_id,
-                "menu": menu.serialize() if menu else None,
-            },
-        )
+    await context.profile.notify(
+        "acapy::webhook::actionmenu",
+        {
+            "connection_id": connection_id,
+            "menu": menu.serialize() if menu else None,
+        },
+    )

--- a/aries_cloudagent/protocols/actionmenu/v1_0/util.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/util.py
@@ -54,7 +54,7 @@ async def save_connection_menu(
                 await storage.delete_record(record)
 
     await context.profile.notify(
-        "acapy::webhook::actionmenu",
+        "acapy::actionmenu::received",
         {
             "connection_id": connection_id,
             "menu": menu.serialize() if menu else None,

--- a/aries_cloudagent/protocols/basicmessage/v1_0/handlers/basicmessage_handler.py
+++ b/aries_cloudagent/protocols/basicmessage/v1_0/handlers/basicmessage_handler.py
@@ -45,7 +45,7 @@ class BasicMessageHandler(BaseHandler):
         if "l10n" in context.message._decorators:
             payload["locale"] = context.message._decorators["l10n"].locale
 
-        await responder.send_webhook("basicmessages", payload)
+        await context.profile.notify("acapy::webhook::basicmessages", payload)
 
         reply = None
         if body:

--- a/aries_cloudagent/protocols/basicmessage/v1_0/handlers/basicmessage_handler.py
+++ b/aries_cloudagent/protocols/basicmessage/v1_0/handlers/basicmessage_handler.py
@@ -45,7 +45,7 @@ class BasicMessageHandler(BaseHandler):
         if "l10n" in context.message._decorators:
             payload["locale"] = context.message._decorators["l10n"].locale
 
-        await context.profile.notify("acapy::webhook::basicmessages", payload)
+        await context.profile.notify("acapy::basicmessage::received", payload)
 
         reply = None
         if body:

--- a/aries_cloudagent/protocols/basicmessage/v1_0/handlers/tests/test_basicmessage_handler.py
+++ b/aries_cloudagent/protocols/basicmessage/v1_0/handlers/tests/test_basicmessage_handler.py
@@ -33,7 +33,7 @@ class TestBasicMessageHandler:
         assert mock_event_bus.events[0] == (
             request_context.profile,
             Event(
-                "acapy::webhook::basicmessages",
+                "acapy::basicmessage::received",
                 {
                     "connection_id": request_context.connection_record.connection_id,
                     "message_id": request_context.message._id,

--- a/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
@@ -22,7 +22,7 @@ class V10CredentialExchange(BaseExchangeRecord):
 
     RECORD_TYPE = "credential_exchange_v10"
     RECORD_ID_NAME = "credential_exchange_id"
-    WEBHOOK_TOPIC = "issue_credential"
+    RECORD_TOPIC = "issue_credential"
     TAG_NAMES = {"~thread_id"} if unencrypted_tags else {"thread_id"}
 
     INITIATOR_SELF = "self"

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -21,7 +21,7 @@ class V20CredExRecord(BaseExchangeRecord):
 
     RECORD_TYPE = "cred_ex_v20"
     RECORD_ID_NAME = "cred_ex_id"
-    WEBHOOK_TOPIC = "issue_credential_v2_0"
+    RECORD_TOPIC = "issue_credential_v2_0"
     TAG_NAMES = {"~thread_id"} if UNENCRYPTED_TAGS else {"thread_id"}
 
     INITIATOR_SELF = "self"

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/detail/dif.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/detail/dif.py
@@ -22,7 +22,7 @@ class V20CredExRecordDIF(BaseRecord):
     RECORD_ID_NAME = "cred_ex_dif_id"
     RECORD_TYPE = "dif_cred_ex_v20"
     TAG_NAMES = {"~cred_ex_id"} if UNENCRYPTED_TAGS else {"cred_ex_id"}
-    WEBHOOK_TOPIC = "issue_credential_v2_0_dif"
+    RECORD_TOPIC = "issue_credential_v2_0_dif"
 
     def __init__(
         self,

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/detail/indy.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/detail/indy.py
@@ -22,7 +22,7 @@ class V20CredExRecordIndy(BaseRecord):
     RECORD_ID_NAME = "cred_ex_indy_id"
     RECORD_TYPE = "indy_cred_ex_v20"
     TAG_NAMES = {"~cred_ex_id"} if UNENCRYPTED_TAGS else {"cred_ex_id"}
-    WEBHOOK_TOPIC = "issue_credential_v2_0_indy"
+    RECORD_TOPIC = "issue_credential_v2_0_indy"
 
     def __init__(
         self,

--- a/aries_cloudagent/protocols/out_of_band/v1_0/models/invitation.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/models/invitation.py
@@ -19,7 +19,7 @@ class InvitationRecord(BaseExchangeRecord):
 
     RECORD_TYPE = "oob_invitation"
     RECORD_ID_NAME = "invitation_id"
-    WEBHOOK_TOPIC = "oob_invitation"
+    RECORD_TOPIC = "oob_invitation"
     TAG_NAMES = {"invi_msg_id", "public_did"}
 
     STATE_INITIAL = "initial"

--- a/aries_cloudagent/protocols/present_proof/v1_0/models/presentation_exchange.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/models/presentation_exchange.py
@@ -21,7 +21,7 @@ class V10PresentationExchange(BaseExchangeRecord):
 
     RECORD_TYPE = "presentation_exchange_v10"
     RECORD_ID_NAME = "presentation_exchange_id"
-    WEBHOOK_TOPIC = "present_proof"
+    RECORD_TOPIC = "present_proof"
     TAG_NAMES = {"~thread_id"} if unencrypted_tags else {"thread_id"}
 
     INITIATOR_SELF = "self"

--- a/aries_cloudagent/protocols/problem_report/v1_0/handler.py
+++ b/aries_cloudagent/protocols/problem_report/v1_0/handler.py
@@ -30,4 +30,6 @@ class ProblemReportHandler(BaseHandler):
             context.message,
         )
 
-        await responder.send_webhook("problem_report", context.message.serialize())
+        await context.profile.notify(
+            "acapy::webhook::problem_report", context.message.serialize()
+        )

--- a/aries_cloudagent/protocols/problem_report/v1_0/handler.py
+++ b/aries_cloudagent/protocols/problem_report/v1_0/handler.py
@@ -31,5 +31,5 @@ class ProblemReportHandler(BaseHandler):
         )
 
         await context.profile.notify(
-            "acapy::webhook::problem_report", context.message.serialize()
+            "acapy::problem_report", context.message.serialize()
         )

--- a/aries_cloudagent/protocols/problem_report/v1_0/tests/test_handler.py
+++ b/aries_cloudagent/protocols/problem_report/v1_0/tests/test_handler.py
@@ -31,5 +31,5 @@ class TestPingHandler:
         assert len(mock_event_bus.events) == 1
         (profile, event) = mock_event_bus.events[0]
         assert profile == request_context.profile
-        assert event.topic == "acapy::webhook::problem_report"
+        assert event.topic == "acapy::problem_report"
         assert event.payload == request_context.message.serialize()

--- a/aries_cloudagent/protocols/problem_report/v1_0/tests/test_handler.py
+++ b/aries_cloudagent/protocols/problem_report/v1_0/tests/test_handler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aries_cloudagent.messaging.base_handler import HandlerException
+from aries_cloudagent.core.event_bus import EventBus, MockEventBus, Event
 from aries_cloudagent.messaging.request_context import RequestContext
 from aries_cloudagent.messaging.responder import MockResponder
 from aries_cloudagent.transport.inbound.receipt import MessageReceipt
@@ -17,6 +17,9 @@ def request_context() -> RequestContext:
 class TestPingHandler:
     @pytest.mark.asyncio
     async def test_problem_report(self, request_context):
+        mock_event_bus = MockEventBus()
+        request_context.profile.context.injector.bind_instance(EventBus, mock_event_bus)
+
         request_context.message_receipt = MessageReceipt()
         request_context.message = ProblemReport()
         request_context.connection_ready = True
@@ -25,6 +28,8 @@ class TestPingHandler:
         await handler.handle(request_context, responder)
         messages = responder.messages
         assert len(messages) == 0
-        hooks = responder.webhooks
-        assert len(hooks) == 1
-        assert hooks[0] == ("problem_report", request_context.message.serialize())
+        assert len(mock_event_bus.events) == 1
+        (profile, event) = mock_event_bus.events[0]
+        assert profile == request_context.profile
+        assert event.topic == "acapy::webhook::problem_report"
+        assert event.payload == request_context.message.serialize()

--- a/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_handler.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_handler.py
@@ -43,8 +43,8 @@ class PingHandler(BaseHandler):
             await responder.send_reply(reply)
 
         if context.settings.get("debug.monitor_ping"):
-            await responder.send_webhook(
-                "ping",
+            await context.profile.notify(
+                "acapy::webhook::ping",
                 {
                     "comment": context.message.comment,
                     "connection_id": context.message_receipt.connection_id,

--- a/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_handler.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_handler.py
@@ -44,7 +44,7 @@ class PingHandler(BaseHandler):
 
         if context.settings.get("debug.monitor_ping"):
             await context.profile.notify(
-                "acapy::webhook::ping",
+                "acapy::ping::received",
                 {
                     "comment": context.message.comment,
                     "connection_id": context.message_receipt.connection_id,

--- a/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_response_handler.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_response_handler.py
@@ -31,7 +31,7 @@ class PingResponseHandler(BaseHandler):
 
         if context.settings.get("debug.monitor_ping"):
             await context.profile.notify(
-                "acapy::webhook::ping",
+                "acapy::ping::response_received",
                 {
                     "comment": context.message.comment,
                     "connection_id": context.message_receipt.connection_id,

--- a/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_response_handler.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_response_handler.py
@@ -30,8 +30,8 @@ class PingResponseHandler(BaseHandler):
         )
 
         if context.settings.get("debug.monitor_ping"):
-            await responder.send_webhook(
-                "ping",
+            await context.profile.notify(
+                "acapy::webhook::ping",
                 {
                     "comment": context.message.comment,
                     "connection_id": context.message_receipt.connection_id,

--- a/aries_cloudagent/revocation/models/issuer_cred_rev_record.py
+++ b/aries_cloudagent/revocation/models/issuer_cred_rev_record.py
@@ -24,7 +24,7 @@ class IssuerCredRevRecord(BaseRecord):
 
     RECORD_TYPE = "issuer_cred_rev"
     RECORD_ID_NAME = "record_id"
-    WEBHOOK_TOPIC = "issuer_cred_rev"
+    RECORD_TOPIC = "issuer_cred_rev"
     TAG_NAMES = {
         "cred_ex_id",
         "cred_def_id",

--- a/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
+++ b/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
@@ -47,7 +47,7 @@ class IssuerRevRegRecord(BaseRecord):
 
     RECORD_ID_NAME = "record_id"
     RECORD_TYPE = "issuer_rev_reg"
-    WEBHOOK_TOPIC = "revocation_registry"
+    RECORD_TOPIC = "revocation_registry"
     LOG_STATE_FLAG = "debug.revocation"
     TAG_NAMES = {
         "cred_def_id",


### PR DESCRIPTION
First stab at the refactor. All the tests are passing and seems to be working fine with the toolbox.

Any event with a topic `acapy::webhook::(.*)` will get forwarded as a webhook. However, I'm thinking now might be a good time to improve the naming convention of these events, while still maintaining backwards compatibility with webhook topics.

i.e.  a mapping from event name to webhook topic might be:
```
{
  "acapy::basicmessage_received": "basicmessages",
  "acapy::ping": "ping",
  "acapy::ping_response": "ping",
  "acapy::driver_get_active_menu": "get-active-menu",
  "acapy::driver_perform_menu_action": "perform-menu-action",
  "acapy::problem_report": "problem_report",
}
```

