### PR TITLE
fix: propagate endpoint from mediation record

### DIFF
--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -456,8 +456,10 @@ async def wallet_set_public_did(request: web.BaseRequest):
         profile=profile, mediation_id=mediation_id, or_default=True
     )
     routing_keys = None
+    mediator_endpoint = None
     if mediation_record:
         routing_keys = mediation_record.routing_keys
+        mediator_endpoint=mediation_record.endpoint
 
     try:
         info, attrib_def = await promote_wallet_public_did(
@@ -468,6 +470,7 @@ async def wallet_set_public_did(request: web.BaseRequest):
             write_ledger=write_ledger,
             connection_id=connection_id,
             routing_keys=routing_keys,
+            mediator_endpoint=mediator_endpoint,
         )
     except LookupError as err:
         raise web.HTTPNotFound(reason=str(err)) from err
@@ -515,6 +518,7 @@ async def promote_wallet_public_did(
     write_ledger: bool = False,
     connection_id: str = None,
     routing_keys: List[str] = None,
+    mediator_endpoint: str = None,
 ) -> DIDInfo:
     """Promote supplied DID to the wallet public DID."""
 
@@ -586,7 +590,7 @@ async def promote_wallet_public_did(
         if not endpoint:
             async with session_fn() as session:
                 wallet = session.inject_or(BaseWallet)
-                endpoint = context.settings.get("default_endpoint")
+                endpoint = mediator_endpoint or context.settings.get("default_endpoint")
                 attrib_def = await wallet.set_did_endpoint(
                     info.did,
                     endpoint,


### PR DESCRIPTION
This PR solves the bug in which the endpoint of an agent behind a mediator is the agent's endpoint rather than the mediator's endpoint.

Signed-off-by: Char Howland <char@indicio.tech>