### PR TITLE
Add supplements and attachments to cred issue message

### DIFF
--- a/aries_cloudagent/messaging/agent_message.py
+++ b/aries_cloudagent/messaging/agent_message.py
@@ -1,7 +1,7 @@
 """Agent message base class and schema."""
 
 from collections import OrderedDict
-from typing import Mapping, Union
+from typing import Mapping, Type, TypeVar, Union
 import uuid
 
 from marshmallow import (
@@ -41,6 +41,9 @@ from .base_message import BaseMessage, DIDCommVersion
 
 class AgentMessageError(BaseModelError):
     """Base exception for agent message issues."""
+
+
+MessageType = TypeVar("MessageType", bound="AgentMessage")
 
 
 class AgentMessage(BaseModel, BaseMessage):
@@ -418,8 +421,11 @@ class AgentMessage(BaseModel, BaseMessage):
 
     @classmethod
     def deserialize(
-        cls, value: dict, msg_format: DIDCommVersion = DIDCommVersion.v1, **kwargs
-    ):
+        cls: Type[MessageType],
+        value: dict,
+        msg_format: DIDCommVersion = DIDCommVersion.v1,
+        **kwargs,
+    ) -> MessageType:
         """Return message object deserialized from value in format specified."""
         if msg_format is DIDCommVersion.v2:
             raise NotImplementedError("DIDComm v2 is not yet supported")

--- a/aries_cloudagent/messaging/models/base.py
+++ b/aries_cloudagent/messaging/models/base.py
@@ -5,7 +5,7 @@ import json
 
 from abc import ABC
 from collections import namedtuple
-from typing import Mapping, Union
+from typing import Mapping, Type, TypeVar, Union
 
 from marshmallow import Schema, post_dump, pre_load, post_load, ValidationError, EXCLUDE
 
@@ -70,6 +70,9 @@ class BaseModelError(BaseError):
     """Base exception class for base model errors."""
 
 
+ModelType = TypeVar("ModelType", bound="BaseModel")
+
+
 class BaseModel(ABC):
     """Base model that provides convenience methods."""
 
@@ -116,7 +119,9 @@ class BaseModel(ABC):
         return self._get_schema_class()
 
     @classmethod
-    def deserialize(cls, obj, unknown: str = None, none2none: str = False):
+    def deserialize(
+        cls: Type[ModelType], obj, unknown: str = None, none2none: str = False
+    ) -> ModelType:
         """
         Convert from JSON representation to a model instance.
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_issue.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_issue.py
@@ -1,6 +1,6 @@
 """Credential issue message."""
 
-from typing import Sequence
+from typing import Optional, Sequence
 
 from marshmallow import EXCLUDE, fields, validates_schema, ValidationError
 
@@ -14,6 +14,7 @@ from .....messaging.valid import UUIDFour
 from ..message_types import CRED_20_ISSUE, PROTOCOL_PACKAGE
 
 from .cred_format import V20CredFormat, V20CredFormatSchema
+from .inner.supplement import Supplement, SupplementSchema
 
 HANDLER_CLASS = f"{PROTOCOL_PACKAGE}.handlers.cred_issue_handler.V20CredIssueHandler"
 
@@ -30,12 +31,14 @@ class V20CredIssue(AgentMessage):
 
     def __init__(
         self,
-        _id: str = None,
+        _id: Optional[str] = None,
         *,
-        replacement_id: str = None,
-        comment: str = None,
-        formats: Sequence[V20CredFormat] = None,
-        credentials_attach: Sequence[AttachDecorator] = None,
+        replacement_id: Optional[str] = None,
+        comment: Optional[str] = None,
+        formats: Optional[Sequence[V20CredFormat]] = None,
+        credentials_attach: Optional[Sequence[AttachDecorator]] = None,
+        supplements: Optional[Sequence[Supplement]] = None,
+        attachments: Optional[Sequence[AttachDecorator]] = None,
         **kwargs,
     ):
         """
@@ -53,6 +56,8 @@ class V20CredIssue(AgentMessage):
         self.comment = comment
         self.formats = list(formats) if formats else []
         self.credentials_attach = list(credentials_attach) if credentials_attach else []
+        self.supplements = supplements or []
+        self.attachments = attachments or []
 
     def attachment(self, fmt: V20CredFormat.Format = None) -> dict:
         """
@@ -110,6 +115,19 @@ class V20CredIssueSchema(AgentMessageSchema):
         required=True,
         data_key="credentials~attach",
         description="Credential attachments",
+    )
+    supplements = fields.Nested(
+        SupplementSchema,
+        description="Supplements to the credential",
+        many=True,
+        required=False,
+    )
+    attachments = fields.Nested(
+        AttachDecoratorSchema,
+        many=True,
+        required=False,
+        description="Attachments of other data associated with the credential",
+        data_key="~attach",
     )
 
     @validates_schema


### PR DESCRIPTION
This PR adds the supplements and attachments to the cred issue message. @frostyfrog this notably does NOT include the fix that we discussed. As it turns out, it would seem the attachment decorator was explicitly excluded from the base message decorator set since it's not defined to be a decorator that can be added to any message. Instead, the right choice was actually to make it a field of the message and just set the data key to `~attach` and then the decorator extractor knows to skip it since it's a defined field on the schema of the message.

Also of note, there's an unfortunate overlap in terminology with the base `credentials~attach` field and access a specific format of the credential from that list. When consuming these changes, be careful to retrieve the generic attachments with `cred_issue.attachments` which will have the type `Sequence[AttachmentDecorator]` and not to mix this up with the method `cred_issue.attachment(format)` which does something very different. We're considering renaming that method to something else but opted to not do that yet for a cleaner change set here.