### PR TITLE
feat: issuer admin api supports supplements and attachments

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -522,6 +522,8 @@ class V20CredManager:
             comment=comment,
             formats=[format for (format, _) in issue_formats],
             credentials_attach=[attach for (_, attach) in issue_formats],
+            supplements=cred_ex_record.supplements or None,
+            attachments=cred_ex_record.attachments or None,
         )
 
         cred_ex_record.state = V20CredExRecord.STATE_ISSUED

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -2,12 +2,14 @@
 
 import logging
 
-from typing import Mapping, Optional, Tuple
+from typing import Mapping, Optional, Sequence, Tuple, Union
+
 
 from ....connections.models.conn_record import ConnRecord
 from ....core.oob_processor import OobRecord
 from ....core.error import BaseError
 from ....core.profile import Profile
+from ....messaging.decorators.attach_decorator import AttachDecorator
 from ....messaging.responder import BaseResponder
 from ....storage.error import StorageError, StorageNotFoundError
 
@@ -19,6 +21,7 @@ from .messages.cred_problem_report import V20CredProblemReport, ProblemReportRea
 from .messages.cred_proposal import V20CredProposal
 from .messages.cred_request import V20CredRequest
 from .messages.inner.cred_preview import V20CredPreview
+from .messages.inner.supplement import Supplement
 from .models.cred_ex_record import V20CredExRecord
 
 LOGGER = logging.getLogger(__name__)
@@ -56,6 +59,8 @@ class V20CredManager:
         connection_id: str,
         cred_proposal: V20CredProposal,
         auto_remove: bool = None,
+        supplements: Sequence[Union[Mapping, Supplement]] = None,
+        attachments: Sequence[Union[Mapping, AttachDecorator]] = None,
     ) -> Tuple[V20CredExRecord, V20CredOffer]:
         """
         Set up a new credential exchange record for an automated send.
@@ -79,6 +84,8 @@ class V20CredManager:
             auto_issue=True,
             auto_remove=auto_remove,
             trace=(cred_proposal._trace is not None),
+            supplements=supplements,
+            attachments=attachments,
         )
         (cred_ex_record, cred_offer) = await self.create_offer(
             cred_ex_record=cred_ex_record,

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/supplement.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/supplement.py
@@ -4,7 +4,7 @@ from typing import Optional, Sequence
 from uuid import uuid4
 from marshmallow import fields, validate
 
-from aries_cloudagent.messaging.valid import UUID4
+from ......messaging.valid import UUIDFour
 from ......messaging.models.base import BaseModel, BaseModelSchema
 
 
@@ -74,12 +74,18 @@ class SupplementSchema(BaseModelSchema):
         validate=validate.OneOf(["hashlink-data", "issuer-credential"]),
     )
 
-    id = fields.Str(description="Unique ID for the supplement", required=False, **UUID4)
+    id = fields.Str(
+        description="Unique ID for the supplement",
+        required=False,
+        example=UUIDFour.EXAMPLE,
+        allow_none=False,
+    )
 
     ref = fields.Str(
         description="Reference to ID of attachment described by this supplement",
+        example=UUIDFour.EXAMPLE,
         required=True,
-        **UUID4
+        allow_none=False,
     )
 
     attrs = fields.Nested(

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -1,24 +1,26 @@
 """Aries#0453 v2.0 credential exchange information with non-secrets storage."""
 
 import logging
+from typing import Any, Mapping, Optional, Sequence, Union
 
-from typing import Any, Mapping, Optional, Union
+from marshmallow import Schema, fields, validate
 
-from marshmallow import fields, Schema, validate
-
+from . import UNENCRYPTED_TAGS
 from .....core.profile import ProfileSession
+from .....messaging.decorators.attach_decorator import (
+    AttachDecorator,
+    AttachDecoratorSchema,
+)
 from .....messaging.models.base_record import BaseExchangeRecord, BaseExchangeSchema
 from .....messaging.valid import UUIDFour
 from .....storage.base import StorageError
-
 from ..messages.cred_format import V20CredFormat
 from ..messages.cred_issue import V20CredIssue, V20CredIssueSchema
-from ..messages.cred_proposal import V20CredProposal, V20CredProposalSchema
 from ..messages.cred_offer import V20CredOffer, V20CredOfferSchema
+from ..messages.cred_proposal import V20CredProposal, V20CredProposalSchema
 from ..messages.cred_request import V20CredRequest, V20CredRequestSchema
 from ..messages.inner.cred_preview import V20CredPreviewSchema
-
-from . import UNENCRYPTED_TAGS
+from ..messages.inner.supplement import Supplement, SupplementSchema
 
 LOGGER = logging.getLogger(__name__)
 
@@ -75,6 +77,8 @@ class V20CredExRecord(BaseExchangeRecord):
         cred_id_stored: str = None,  # backward compat: BaseRecord.from_storage()
         conn_id: str = None,  # backward compat: BaseRecord.from_storage()
         by_format: Mapping = None,  # backward compat: BaseRecord.from_storage()
+        supplements: Sequence[Union[Mapping, Supplement]] = None,
+        attachments: Sequence[Union[Mapping, AttachDecorator]] = None,
         **kwargs,
     ):
         """Initialize a new V20CredExRecord."""
@@ -94,6 +98,12 @@ class V20CredExRecord(BaseExchangeRecord):
         self.auto_issue = auto_issue
         self.auto_remove = auto_remove
         self.error_msg = error_msg
+        self.supplements = [
+            Supplement.serde(supplement).de for supplement in supplements or []
+        ]
+        self.attachments = [
+            AttachDecorator.serde(attachment).de for attachment in attachments or []
+        ]
 
     @property
     def cred_ex_id(self) -> str:
@@ -209,6 +219,13 @@ class V20CredExRecord(BaseExchangeRecord):
                     "cred_issue",
                 )
                 if getattr(self, prop) is not None
+            },
+            **{
+                prop: [item.serialize() for item in getattr(self, prop)]
+                for prop in (
+                    "supplements",
+                    "attachments",
+                )
             },
         }
 
@@ -391,4 +408,16 @@ class V20CredExRecordSchema(BaseExchangeSchema):
         required=False,
         description="Error message",
         example="The front fell off",
+    )
+    supplements = fields.Nested(
+        SupplementSchema,
+        description="Supplements to the credential",
+        many=True,
+        required=False,
+    )
+    attachments = fields.Nested(
+        AttachDecoratorSchema,
+        many=True,
+        required=False,
+        description="Attachments of other data associated with the credential",
     )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -226,6 +226,7 @@ class V20CredExRecord(BaseExchangeRecord):
                     "supplements",
                     "attachments",
                 )
+                if getattr(self, prop)
             },
         }
 


### PR DESCRIPTION
This PR adds supplements and attachments attributes to the `POST /issue-credential-2.0/send` request body so that an issuer can specify binary data alongside the credential. It is expected that the issuer can prepare their own hashlinks (or that they'll use an endpoint we are yet to create to help create the hashlinks) and knows how to structure the supplements and attachments.

Also notable, I relaxed the UUID4 format validation on the supplement IDs and ref attributes. Attachment IDs are not required to be uuid4 (though they commonly are).