### PR TITLE
Fix/attribute retrieval

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -641,12 +641,14 @@ class V20CredManager:
                 await cred_format.handler(self.profile).store_credential(
                     cred_ex_record, cred_id
                 )
-                async with self.profile.session() as session:
-                    await AttachmentDataRecord.save_attachments(
-                        session=session,
-                        supplements=supplements,
-                        attachments=attachments,
-                    )
+                if supplements:
+                    async with self.profile.session() as session:
+                        await AttachmentDataRecord.save_attachments(
+                            session=session,
+                            supplements=supplements,
+                            attachments=attachments,
+                            cred_id=cred_id,
+                        )
                 # TODO: if storing multiple credentials we can't reuse the same id
                 cred_id = None
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_hashlink.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_hashlink.py
@@ -2,7 +2,9 @@ from ..hashlink import Hashlink
 
 EXAMPLE_DATA = b"Hello World!"
 EXAMPLE_LINK = "hl:zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e:zuh8iaLobXC8g9tfma1CSTtYBakXeSTkHrYA5hmD4F7dCLw8XYwZ1GWyJ3zwF"
-EXAMPLE_DATA_SHA = bytes.fromhex("7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069")
+EXAMPLE_DATA_SHA = bytes.fromhex(
+    "7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069"
+)
 
 
 def test_example_link():
@@ -25,11 +27,13 @@ def test_serialize_metadata():
 
     assert hashlink._serialize_metadata() == EXAMPLE_LINK.split(":")[2]
 
+
 def test_deserialize_data():
 
     data = EXAMPLE_LINK.split(":")[1]
 
     assert Hashlink._deserialize_data(data) == EXAMPLE_DATA_SHA
+
 
 def test_verify_link():
 

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/indy/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/indy/handler.py
@@ -97,9 +97,7 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
         )
 
     async def create_bound_request(
-        self,
-        pres_ex_record: V20PresExRecord,
-        request_data: dict = None,
+        self, pres_ex_record: V20PresExRecord, request_data: dict = None
     ) -> Tuple[V20PresFormat, AttachDecorator]:
         """
         Create a presentation request bound to a proposal.
@@ -129,9 +127,7 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
         return self.get_format_data(PRES_20_REQUEST, indy_proof_request)
 
     async def create_pres(
-        self,
-        pres_ex_record: V20PresExRecord,
-        request_data: dict = None,
+        self, pres_ex_record: V20PresExRecord, request_data: dict = None
     ) -> Tuple[V20PresFormat, AttachDecorator]:
         """Create a presentation."""
         requested_credentials = {}
@@ -141,12 +137,10 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
                 indy_proof_request = proof_request.attachment(
                     IndyPresExchangeHandler.format
                 )
-                requested_credentials = (
-                    await indy_proof_req_preview2indy_requested_creds(
-                        indy_proof_request,
-                        preview=None,
-                        holder=self._profile.inject(IndyHolder),
-                    )
+                requested_credentials = await indy_proof_req_preview2indy_requested_creds(
+                    indy_proof_request,
+                    preview=None,
+                    holder=self._profile.inject(IndyHolder),
                 )
             except ValueError as err:
                 LOGGER.warning(f"{err}")
@@ -163,8 +157,7 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
                 }
         indy_handler = IndyPresExchHandler(self._profile)
         indy_proof = await indy_handler.return_presentation(
-            pres_ex_record=pres_ex_record,
-            requested_credentials=requested_credentials,
+            pres_ex_record=pres_ex_record, requested_credentials=requested_credentials
         )
         return self.get_format_data(PRES_20, indy_proof)
 

--- a/aries_cloudagent/wallet/tests/test_attachment_data_record.py
+++ b/aries_cloudagent/wallet/tests/test_attachment_data_record.py
@@ -13,7 +13,7 @@ def create_supplement():
     def _create_supplement(num):
         return Supplement(
             type="hashlink_data",
-            attrs={"key": "field", "value": "<fieldname>"},
+            attrs=[{"key": "field", "value": "<fieldname>"}],
             ref=None,
             id="attachment_id_" + str(num),
         )
@@ -76,12 +76,13 @@ def test_match_by_attachment_id(create_supplement, create_attachment):
     supplements = [create_supplement(1), create_supplement(2)]
     attachments = [create_attachment(1), create_attachment(2)]
     result = AttachmentDataRecord.match_by_attachment_id(
-        supplements, attachments, cred_id="test_cred_id", attribute="test_attribute"
+        supplements, attachments, cred_id="test_cred_id"
     )
 
     for record in result:
         assert type(record) == AttachmentDataRecord
         assert record.attachment_id == record.supplement.id
+        assert record.attribute == "<fieldname>"
 
 
 @pytest.mark.asyncio
@@ -91,11 +92,7 @@ async def test_save_attachments(create_supplement, create_attachment, profile):
         supplements = [create_supplement(1), create_supplement(2)]
         attachments = [create_attachment(1), create_attachment(2)]
         result = await AttachmentDataRecord.save_attachments(
-            session,
-            supplements,
-            attachments,
-            cred_id="test_cred_id",
-            attribute="test_attribute",
+            session, supplements, attachments, cred_id="test_cred_id"
         )
 
         assert type(result) == list


### PR DESCRIPTION
This PR removes `attribute` as a parameter in `AttachmentDataRecords` methods `match_by_attachment_id()` and `save_attachments()` and instead retrieves the `attribute` from the `supplement`.