### PR TITLE
Feature/0.7.4 ssl public did

### DIFF
--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -89,17 +89,15 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         if not routing_keys:
             routing_keys = []
 
-        endpoint_dict = {"endpoint": endpoint}
-
         if all_exist_endpoints:
-            all_exist_endpoints[endpoint_type.indy] = endpoint_dict
-            endpoint_dict["routingKeys"] = routing_keys
+            all_exist_endpoints[endpoint_type.indy] = endpoint
+            all_exist_endpoints["routingKeys"] = routing_keys
             attr_json = json.dumps({"endpoint": all_exist_endpoints})
 
         else:
-            endpoint_val = {endpoint_type.indy: endpoint_dict}
+            endpoint_dict = {endpoint_type.indy: endpoint}
             endpoint_dict["routingKeys"] = routing_keys
-            attr_json = json.dumps({"endpoint": endpoint_val})
+            attr_json = json.dumps({"endpoint": endpoint_dict})
 
         return attr_json
 

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -8,7 +8,7 @@ from datetime import date, datetime
 from io import StringIO
 from os import path
 from time import time
-from typing import TYPE_CHECKING, List, Sequence, Tuple, Optional
+from typing import List, Sequence, Tuple, Optional
 
 import indy.ledger
 import indy.pool

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -2285,17 +2285,37 @@ class TestIndySdkLedger(AsyncTestCase):
             attr_json = await ledger._construct_attr_json(
                 "https://url",
                 EndpointType.ENDPOINT,
-                all_exist_endpoints={"Endpoint": "https://endpoint"},
                 routing_keys=["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
             )
         assert attr_json == json.dumps(
             {
                 "endpoint": {
-                    "Endpoint": "https://endpoint",
-                    "endpoint": {
-                        "endpoint": "https://url",
-                        "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
-                    },
+                    "endpoint": "https://url",
+                    "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
+                }
+            }
+        )
+
+    @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_open")
+    @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_close")
+    @pytest.mark.asyncio
+    async def test_construct_attr_json_with_routing_keys_all_exist_endpoints(
+        self, mock_close, mock_open
+    ):
+        ledger = IndySdkLedger(IndySdkLedgerPool("name", checked=True), self.profile)
+        async with ledger:
+            attr_json = await ledger._construct_attr_json(
+                "https://url",
+                EndpointType.ENDPOINT,
+                all_exist_endpoints={"profile": "https://endpoint/profile"},
+                routing_keys=["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
+            )
+        assert attr_json == json.dumps(
+            {
+                "endpoint": {
+                    "profile": "https://endpoint/profile",
+                    "endpoint": "https://url",
+                    "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
                 }
             }
         )

--- a/aries_cloudagent/ledger/tests/test_indy_vdr.py
+++ b/aries_cloudagent/ledger/tests/test_indy_vdr.py
@@ -605,27 +605,24 @@ class TestIndyVdrLedger:
         "all_exist_endpoints, routing_keys, result",
         [
             (
-                {"Endpoint": "https://endpoint"},
+                {"profile": "https://endpoint/profile"},
                 ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
                 {
                     "endpoint": {
-                        "Endpoint": "https://endpoint",
-                        "endpoint": {
-                            "endpoint": "https://url",
-                            "routingKeys": [
-                                "3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"
-                            ],
-                        },
+                        "profile": "https://endpoint/profile",
+                        "endpoint": "https://url",
+                        "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
                     }
                 },
             ),
             (
-                {"Endpoint": "https://endpoint"},
+                {"profile": "https://endpoint/profile"},
                 None,
                 {
                     "endpoint": {
-                        "Endpoint": "https://endpoint",
-                        "endpoint": {"endpoint": "https://url", "routingKeys": []},
+                        "profile": "https://endpoint/profile",
+                        "endpoint": "https://url",
+                        "routingKeys": [],
                     }
                 },
             ),
@@ -634,21 +631,24 @@ class TestIndyVdrLedger:
                 ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
                 {
                     "endpoint": {
-                        "endpoint": {
-                            "endpoint": "https://url",
-                            "routingKeys": [
-                                "3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"
-                            ],
-                        }
+                        "endpoint": "https://url",
+                        "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
                     }
                 },
             ),
+            (None, None, {"endpoint": {"endpoint": "https://url", "routingKeys": []}}),
             (
-                None,
-                None,
+                {
+                    "profile": "https://endpoint/profile",
+                    "spec_divergent_endpoint": "https://endpoint",
+                },
+                ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
                 {
                     "endpoint": {
-                        "endpoint": {"endpoint": "https://url", "routingKeys": []}
+                        "profile": "https://endpoint/profile",
+                        "spec_divergent_endpoint": "https://endpoint",
+                        "endpoint": "https://url",
+                        "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
                     }
                 },
             ),

--- a/aries_cloudagent/resolver/default/indy.py
+++ b/aries_cloudagent/resolver/default/indy.py
@@ -3,7 +3,8 @@
 Resolution is performed using the IndyLedger class.
 """
 
-from typing import Any, Mapping, Pattern
+import logging
+from typing import Optional, Pattern
 
 from pydid import DID, DIDDocumentBuilder
 from pydid.verification_method import Ed25519VerificationKey2018, VerificationMethod
@@ -20,6 +21,8 @@ from ...messaging.valid import IndyDID
 from ...multitenant.base import BaseMultitenantManager
 
 from ..base import BaseDIDResolver, DIDNotFound, ResolverError, ResolverType
+
+LOGGER = logging.getLogger(__name__)
 
 
 class NoIndyLedger(ResolverError):
@@ -46,59 +49,82 @@ class IndyDIDResolver(BaseDIDResolver):
         """Return supported_did_regex of Indy DID Resolver."""
         return IndyDID.PATTERN
 
-    def _add_endpoint_as_endpoint_value_pair(
+    def process_endpoint_types(self, types):
+        """Process endpoint types to return only expected types,
+        subset of expected types, or default types.
+        """
+        expected_types = ["endpoint", "did-communication", "DIDComm"]
+        default_types = ["endpoint", "did-communication"]
+        if len(types) <= 0:
+            return default_types
+        for type in types:
+            if type not in expected_types:
+                return default_types
+        return types
+
+    def add_services(
         self,
         builder: DIDDocumentBuilder,
-        endpoint: str,
-        recipient_key: VerificationMethod,
+        endpoints: Optional[dict],
+        recipient_key: VerificationMethod = None,
     ):
-        builder.service.add_didcomm(
-            ident=self.SERVICE_TYPE_DID_COMMUNICATION,
-            type_=self.SERVICE_TYPE_DID_COMMUNICATION,
-            service_endpoint=endpoint,
-            priority=1,
-            recipient_keys=[recipient_key],
-            routing_keys=[],
-        )
+        """Add services."""
+        if not endpoints:
+            return
 
-    def _add_endpoint_as_map(
-        self,
-        builder: DIDDocumentBuilder,
-        endpoint: Mapping[str, Any],
-        recipient_key: VerificationMethod,
-    ):
-        types = endpoint.get("types", [self.SERVICE_TYPE_DID_COMMUNICATION])
-        routing_keys = endpoint.get("routingKeys", [])
-        endpoint_url = endpoint.get("endpoint")
-        if not endpoint_url:
-            raise ValueError("endpoint url not found in endpoint attrib")
+        endpoint = endpoints.get("endpoint")
+        routing_keys = endpoints.get("routingKeys", [])
+        types = endpoints.get("types", [self.SERVICE_TYPE_DID_COMMUNICATION])
 
-        if self.SERVICE_TYPE_DIDCOMM in types:
-            builder.service.add(
-                ident="#didcomm-1",
-                type_=self.SERVICE_TYPE_DIDCOMM,
-                service_endpoint=endpoint_url,
-                recipient_keys=[recipient_key.id],
-                routing_keys=routing_keys,
-                accept=["didcomm/v2"],
+        other_endpoints = {
+            key: endpoints[key]
+            for key in ("profile", "linked_domains")
+            if key in endpoints
+        }
+
+        if endpoint:
+            processed_types = self.process_endpoint_types(types)
+
+            if self.SERVICE_TYPE_ENDPOINT in processed_types:
+                builder.service.add(
+                    ident="endpoint",
+                    service_endpoint=endpoint,
+                    type_=self.SERVICE_TYPE_ENDPOINT,
+                )
+
+            if self.SERVICE_TYPE_DID_COMMUNICATION in processed_types:
+                builder.service.add(
+                    ident="did-communication",
+                    type_=self.SERVICE_TYPE_DID_COMMUNICATION,
+                    service_endpoint=endpoint,
+                    priority=1,
+                    routing_keys=routing_keys,
+                    recipient_keys=[recipient_key.id],
+                    accept=["didcomm/aip2;env=rfc19"],
+                )
+
+            if self.SERVICE_TYPE_DIDCOMM in types:
+                builder.service.add(
+                    ident="#didcomm-1",
+                    type_=self.SERVICE_TYPE_DIDCOMM,
+                    service_endpoint=endpoint,
+                    recipient_keys=[recipient_key.id],
+                    routing_keys=routing_keys,
+                    accept=["didcomm/v2"],
+                )
+                builder.context.append(self.CONTEXT_DIDCOMM_V2)
+        else:
+            LOGGER.warning(
+                "No endpoint for DID although endpoint attrib was resolvable"
             )
-            builder.context.append(self.CONTEXT_DIDCOMM_V2)
-        if self.SERVICE_TYPE_DID_COMMUNICATION in types:
-            builder.service.add(
-                ident="did-communication",
-                type_=self.SERVICE_TYPE_DID_COMMUNICATION,
-                service_endpoint=endpoint_url,
-                priority=1,
-                routing_keys=routing_keys,
-                recipient_keys=[recipient_key.id],
-                accept=["didcomm/aip2;env=rfc19"],
-            )
-        if self.SERVICE_TYPE_ENDPOINT in types:
-            builder.service.add(
-                ident="endpoint",
-                service_endpoint=endpoint_url,
-                type_=self.SERVICE_TYPE_ENDPOINT,
-            )
+
+        if other_endpoints:
+            for type_, endpoint in other_endpoints.items():
+                builder.service.add(
+                    ident=type_,
+                    type_=EndpointType.get(type_).w3c,
+                    service_endpoint=endpoint,
+                )
 
     async def _resolve(self, profile: Profile, did: str) -> dict:
         """Resolve an indy DID."""
@@ -119,7 +145,7 @@ class IndyDIDResolver(BaseDIDResolver):
         try:
             async with ledger:
                 recipient_key = await ledger.get_key_for_did(did)
-                endpoints = await ledger.get_all_endpoints_for_did(did)
+                endpoints: Optional[dict] = await ledger.get_all_endpoints_for_did(did)
         except LedgerError as err:
             raise DIDNotFound(f"DID {did} could not be resolved") from err
 
@@ -130,22 +156,7 @@ class IndyDIDResolver(BaseDIDResolver):
         )
         builder.authentication.reference(vmethod.id)
         builder.assertion_method.reference(vmethod.id)
-        if endpoints:
-            for type_, endpoint in endpoints.items():
-                if type_ == EndpointType.ENDPOINT.indy:
-                    if isinstance(endpoint, dict):
-                        self._add_endpoint_as_map(builder, endpoint, vmethod)
-                    else:
-                        self._add_endpoint_as_endpoint_value_pair(
-                            builder, endpoint, vmethod
-                        )
-                else:
-                    # Accept all service types for now, i.e. profile, linked_domains
-                    builder.service.add(
-                        ident=type_,
-                        type_=type_,
-                        service_endpoint=endpoint,
-                    )
+        self.add_services(builder, endpoints, vmethod)
 
         result = builder.build()
         return result.serialize()

--- a/aries_cloudagent/resolver/default/indy.py
+++ b/aries_cloudagent/resolver/default/indy.py
@@ -50,8 +50,10 @@ class IndyDIDResolver(BaseDIDResolver):
         return IndyDID.PATTERN
 
     def process_endpoint_types(self, types):
-        """Process endpoint types to return only expected types,
-        subset of expected types, or default types.
+        """Process endpoint types.
+
+        Returns expected types, subset of expected types,
+        or default types.
         """
         expected_types = ["endpoint", "did-communication", "DIDComm"]
         default_types = ["endpoint", "did-communication"]

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -11,7 +11,6 @@ from aiohttp_apispec import (
     request_schema,
     response_schema,
 )
-import logging
 from marshmallow import fields, validate
 
 from ..admin.request_context import AdminRequestContext
@@ -459,7 +458,7 @@ async def wallet_set_public_did(request: web.BaseRequest):
     mediator_endpoint = None
     if mediation_record:
         routing_keys = mediation_record.routing_keys
-        mediator_endpoint=mediation_record.endpoint
+        mediator_endpoint = mediation_record.endpoint
 
     try:
         info, attrib_def = await promote_wallet_public_did(


### PR DESCRIPTION
This PR backports the endpoint attrib structure fix in PR #1934. It implements the solution discussed in https://github.com/hyperledger/aries-cloudagent-python/issues/1928 to resolve an issue with the endpoint attrib structure. We have brought the structure into alignment with the did:sov specification by removing the nested endpoint structure and ensuring that service types `profile` and `linked_domains` can be used. This solution is interoperable with AFJ, which also supports endpoint attrib data in the following manner:

```json
{
  "endpoint": "https://example.com",
  "types": ["did-communication", ...],
  "routingKeys": [...],
  "profile": "https://example.com/profile",
  "linked_domains": "https://example.com/linked-domains",
}
```