### PR TITLE
fix: public did mediator routing keys as did keys

### DIFF
--- a/aries_cloudagent/connections/base_manager.py
+++ b/aries_cloudagent/connections/base_manager.py
@@ -263,16 +263,18 @@ class BaseConnectionManager:
 
         endpoint = first_didcomm_service.service_endpoint
         recipient_keys: List[VerificationMethod] = [
-            doc.dereference(url) for url in first_didcomm_service.recipient_keys
+            await resolver.dereference(self._profile, url, document=doc)
+            for url in first_didcomm_service.recipient_keys
         ]
         routing_keys: List[VerificationMethod] = [
-            doc.dereference(url) for url in first_didcomm_service.routing_keys
+            await resolver.dereference(self._profile, url, document=doc)
+            for url in first_didcomm_service.routing_keys
         ]
 
         for key in [*recipient_keys, *routing_keys]:
             if not isinstance(key, self.SUPPORTED_KEY_TYPES):
                 raise BaseConnectionManagerError(
-                    f"Key type {key.type} is not supported"
+                    f"Key type {type(key).__name__} is not supported"
                 )
 
         return (

--- a/aries_cloudagent/messaging/jsonld/routes.py
+++ b/aries_cloudagent/messaging/jsonld/routes.py
@@ -5,7 +5,6 @@ from aiohttp_apispec import docs, request_schema, response_schema
 from marshmallow import INCLUDE, Schema, fields
 from pydid.verification_method import (
     Ed25519VerificationKey2018,
-    KnownVerificationMethods,
 )
 
 from ...admin.request_context import AdminRequestContext
@@ -148,7 +147,6 @@ async def verify(request: web.BaseRequest):
                 vmethod = await resolver.dereference(
                     profile,
                     doc["proof"]["verificationMethod"],
-                    cls=KnownVerificationMethods,
                 )
 
                 if not isinstance(vmethod, SUPPORTED_VERIFICATION_METHOD_TYPES):

--- a/aries_cloudagent/messaging/jsonld/tests/test_routes.py
+++ b/aries_cloudagent/messaging/jsonld/tests/test_routes.py
@@ -234,22 +234,22 @@ async def test_verify_bad_ver_meth_deref_req_error(
     assert "error" in mock_response.call_args[0][0]
 
 
-@pytest.mark.asyncio
-async def test_verify_bad_ver_meth_not_ver_meth(
-    mock_resolver, mock_verify_request, mock_response, request_body
-):
-    request_body["doc"]["proof"][
-        "verificationMethod"
-    ] = "did:example:1234abcd#did-communication"
-    await test_module.verify(mock_verify_request(request_body))
-    assert "error" in mock_response.call_args[0][0]
-
-
+@pytest.mark.parametrize(
+    "vmethod",
+    [
+        "did:example:1234abcd#key-2",
+        "did:example:1234abcd#did-communication",
+    ],
+)
 @pytest.mark.asyncio
 async def test_verify_bad_vmethod_unsupported(
-    mock_resolver, mock_verify_request, mock_response, request_body
+    mock_resolver,
+    mock_verify_request,
+    mock_response,
+    request_body,
+    vmethod,
 ):
-    request_body["doc"]["proof"]["verificationMethod"] = "did:example:1234abcd#key-2"
+    request_body["doc"]["proof"]["verificationMethod"] = vmethod
     with pytest.raises(web.HTTPBadRequest):
         await test_module.verify(mock_verify_request(request_body))
 

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
@@ -2375,6 +2375,9 @@ class TestConnectionManager(AsyncTestCase):
                 return_value=self.test_endpoint
             )
             self.resolver.resolve = async_mock.CoroutineMock(return_value=did_doc)
+            self.resolver.dereference = async_mock.CoroutineMock(
+                return_value = did_doc.verification_method[0]
+            )
             self.context.injector.bind_instance(DIDResolver, self.resolver)
 
             local_did = await session.wallet.create_local_did(
@@ -2444,6 +2447,9 @@ class TestConnectionManager(AsyncTestCase):
                 return_value=self.test_endpoint
             )
             self.resolver.resolve = async_mock.CoroutineMock(return_value=did_doc)
+            self.resolver.dereference = async_mock.CoroutineMock(
+                return_value = did_doc.verification_method[0]
+            )
             self.context.injector.bind_instance(DIDResolver, self.resolver)
             local_did = await session.wallet.create_local_did(
                 method=DIDMethod.SOV,
@@ -2595,6 +2601,9 @@ class TestConnectionManager(AsyncTestCase):
                 return_value=self.test_endpoint
             )
             self.resolver.resolve = async_mock.CoroutineMock(return_value=did_doc)
+            self.resolver.dereference = async_mock.CoroutineMock(
+                return_value = did_doc.verification_method[0]
+            )
             self.context.injector.bind_instance(DIDResolver, self.resolver)
             local_did = await session.wallet.create_local_did(
                 method=DIDMethod.SOV,
@@ -2666,6 +2675,9 @@ class TestConnectionManager(AsyncTestCase):
 
             self.resolver = async_mock.MagicMock()
             self.resolver.resolve = async_mock.CoroutineMock(return_value=did_doc)
+            self.resolver.dereference = async_mock.CoroutineMock(
+                return_value = did_doc.verification_method[0]
+            )
             self.context.injector.bind_instance(DIDResolver, self.resolver)
 
             local_did = await session.wallet.create_local_did(

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -224,6 +224,7 @@ class OutOfBandManager(BaseConnectionManager):
             async with self.profile.session() as session:
                 wallet = session.inject(BaseWallet)
                 public_did = await wallet.get_public_did()
+
             if not public_did:
                 raise OutOfBandManagerError(
                     "Cannot create public invitation with no public DID"

--- a/aries_cloudagent/resolver/default/tests/test_indy.py
+++ b/aries_cloudagent/resolver/default/tests/test_indy.py
@@ -17,7 +17,7 @@ from ....multitenant.base import BaseMultitenantManager
 from ....multitenant.manager import MultitenantManager
 
 from ...base import DIDNotFound, ResolverError
-from ..indy import IndyDIDResolver
+from ..indy import IndyDIDResolver, _routing_keys_as_did_key_urls
 
 # pylint: disable=W0621
 TEST_DID0 = "did:sov:WgWxqztrNooG92RXvxSTWv"
@@ -118,7 +118,7 @@ class TestIndyResolver:
         """Test that new attrib structure is supported."""
         example = {
             "endpoint": "https://example.com/endpoint",
-            "routingKeys": ["a-routing-key"],
+            "routingKeys": ["HQhjaj4mcaS3Xci27a9QhnBrNpS91VNFUU4TDrtMxa9j"],
             "types": ["DIDComm", "did-communication", "endpoint"],
             "profile": "https://example.com",
             "linked_domains": "https://example.com",
@@ -168,3 +168,18 @@ class TestIndyResolver:
     )
     def test_process_endpoint_types(self, resolver: IndyDIDResolver, types, result):
         assert resolver.process_endpoint_types(types) == result
+
+    @pytest.mark.parametrize(
+        "keys",
+        [
+            ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
+            ["did:key:z6MkgzZFYHiH9RhyMmkoyvNvVwnvgLxkVrJbureLx9HXsuKA"],
+            [
+                "did:key:z6MkgzZFYHiH9RhyMmkoyvNvVwnvgLxkVrJbureLx9HXsuKA#z6MkgzZFYHiH9RhyMmkoyvNvVwnvgLxkVrJbureLx9HXsuKA"
+            ],
+        ],
+    )
+    def test_routing_keys_as_did_key_urls(self, keys):
+        for key in _routing_keys_as_did_key_urls(keys):
+            assert key.startswith("did:key:")
+            assert "#" in key

--- a/aries_cloudagent/resolver/did_resolver.py
+++ b/aries_cloudagent/resolver/did_resolver.py
@@ -8,10 +8,11 @@ retrieving did's from different sources provided by the method type.
 from datetime import datetime
 from itertools import chain
 import logging
-from typing import Sequence, Tuple, Type, TypeVar, Union
+from typing import Optional, Sequence, Tuple, Union
 
-from pydid import DID, DIDError, DIDUrl, Resource, NonconformantDocument
-from pydid.doc.doc import IDNotFoundError
+from pydid import DID, DIDError, DIDUrl, Resource
+import pydid
+from pydid.doc.doc import BaseDIDDocument, IDNotFoundError
 
 from ..core.profile import Profile
 from .base import (
@@ -25,9 +26,6 @@ from .base import (
 from .did_resolver_registry import DIDResolverRegistry
 
 LOGGER = logging.getLogger(__name__)
-
-
-ResourceType = TypeVar("ResourceType", bound=Resource)
 
 
 class DIDResolver:
@@ -103,8 +101,12 @@ class DIDResolver:
         return resolvers
 
     async def dereference(
-        self, profile: Profile, did_url: str, *, cls: Type[ResourceType] = Resource
-    ) -> ResourceType:
+        self,
+        profile: Profile,
+        did_url: str,
+        *,
+        document: Optional[BaseDIDDocument] = None,
+    ) -> Resource:
         """Dereference a DID URL to its corresponding DID Doc object."""
         # TODO Use cached DID Docs when possible
         try:
@@ -116,12 +118,15 @@ class DIDResolver:
                 "Failed to parse DID URL from {}".format(did_url)
             ) from err
 
-        doc_dict = await self.resolve(profile, parsed.did)
-        # Use non-conformant doc as the "least common denominator"
+        if document and parsed.did != document.id:
+            document = None
+
+        if not document:
+            doc_dict = await self.resolve(profile, parsed.did)
+            document = pydid.deserialize_document(doc_dict)
+
         try:
-            return NonconformantDocument.deserialize(doc_dict).dereference_as(
-                cls, parsed
-            )
+            return document.dereference(parsed)
         except IDNotFoundError as error:
             raise ResolverError(
                 "Failed to dereference DID URL: {}".format(error)

--- a/aries_cloudagent/resolver/tests/test_did_resolver.py
+++ b/aries_cloudagent/resolver/tests/test_did_resolver.py
@@ -7,7 +7,7 @@ import re
 import pytest
 
 from asynctest import mock as async_mock
-from pydid import DID, DIDDocument, VerificationMethod
+from pydid import DID, DIDDocument, VerificationMethod, BasicDIDDocument
 
 from ..base import (
     BaseDIDResolver,
@@ -158,6 +158,17 @@ async def test_dereference(resolver, profile):
     expected: dict = DOC["verificationMethod"][0]
     actual: VerificationMethod = await resolver.dereference(profile, url)
     assert expected == actual.serialize()
+
+
+@pytest.mark.asyncio
+async def test_dereference_diddoc(resolver, profile):
+    url = "did:example:1234abcd#4"
+    doc = BasicDIDDocument(
+        id="did:example:z6Mkmpe2DyE4NsDiAb58d75hpi1BjqbH6wYMschUkjWDEEuR"
+    )
+    result = await resolver.dereference(profile, url, document=doc)
+    assert isinstance(result, VerificationMethod)
+    assert result.id == url
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Corresponding PR opened to HL. We should add unit tests before merging and make sure that if a did:key value is written that is not a did:key URL that we transform to did:key url.

cc @cjhowland @reflectivedevelopment 