### PR TITLE
refactor: rename revocation status list to revocation list

### DIFF
--- a/aries_cloudagent/anoncreds/base.py
+++ b/aries_cloudagent/anoncreds/base.py
@@ -11,12 +11,12 @@ from .models.anoncreds_cred_def import (
     GetCredDefResult,
 )
 from .models.anoncreds_revocation import (
-    GetRevStatusListResult,
+    GetRevListResult,
     AnonCredsRegistryGetRevocationRegistryDefinition,
     RevRegDef,
     RevRegDefResult,
-    RevStatusList,
-    RevStatusListResult,
+    RevList,
+    RevListResult,
 )
 from .models.anoncreds_schema import AnonCredsSchema, GetSchemaResult, SchemaResult
 
@@ -110,9 +110,9 @@ class BaseAnonCredsResolver(BaseAnonCredsHandler):
         """Get a revocation registry definition from the registry."""
 
     @abstractmethod
-    async def get_revocation_status_list(
+    async def get_revocation_list(
         self, profile: Profile, revocation_registry_id: str, timestamp: int
-    ) -> GetRevStatusListResult:
+    ) -> GetRevListResult:
         """Get a revocation list from the registry."""
 
 
@@ -146,22 +146,22 @@ class BaseAnonCredsRegistrar(BaseAnonCredsHandler):
         """Register a revocation registry definition on the registry."""
 
     @abstractmethod
-    async def register_revocation_status_list(
+    async def register_revocation_list(
         self,
         profile: Profile,
         rev_reg_def: RevRegDef,
-        rev_status_list: RevStatusList,
+        rev_list: RevList,
         options: Optional[dict] = None,
-    ) -> RevStatusListResult:
+    ) -> RevListResult:
         """Register a revocation list on the registry."""
 
     @abstractmethod
-    async def update_revocation_status_list(
+    async def update_revocation_list(
         self,
         profile: Profile,
         rev_reg_def: RevRegDef,
-        prev_status_list: RevStatusList,
-        curr_status_list: RevStatusList,
+        prev_list: RevList,
+        curr_list: RevList,
         options: Optional[dict] = None,
-    ) -> RevStatusListResult:
+    ) -> RevListResult:
         """Update a revocation list on the registry."""

--- a/aries_cloudagent/anoncreds/default/did_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/did_indy/registry.py
@@ -11,12 +11,12 @@ from ...models.anoncreds_cred_def import (
     GetCredDefResult,
 )
 from ...models.anoncreds_revocation import (
-    GetRevStatusListResult,
+    GetRevListResult,
     AnonCredsRegistryGetRevocationRegistryDefinition,
     RevRegDef,
     RevRegDefResult,
-    RevStatusList,
-    RevStatusListResult,
+    RevList,
+    RevListResult,
 )
 from ...models.anoncreds_schema import AnonCredsSchema, GetSchemaResult, SchemaResult
 from ...base import BaseAnonCredsRegistrar, BaseAnonCredsResolver
@@ -83,29 +83,29 @@ class DIDIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         """Register a revocation registry definition on the registry."""
         raise NotImplementedError()
 
-    async def get_revocation_status_list(
+    async def get_revocation_list(
         self, profile: Profile, revocation_registry_id: str, timestamp: int
-    ) -> GetRevStatusListResult:
+    ) -> GetRevListResult:
         """Get a revocation list from the registry."""
         raise NotImplementedError()
 
-    async def register_revocation_status_list(
+    async def register_revocation_list(
         self,
         profile: Profile,
         rev_reg_def: RevRegDef,
-        rev_status_list: RevStatusList,
+        rev_list: RevList,
         options: Optional[dict] = None,
-    ) -> RevStatusListResult:
+    ) -> RevListResult:
         """Register a revocation list on the registry."""
         raise NotImplementedError()
 
-    async def update_revocation_status_list(
+    async def update_revocation_list(
         self,
         profile: Profile,
         rev_reg_def: RevRegDef,
-        prev_status_list: RevStatusList,
-        curr_status_list: RevStatusList,
+        prev_list: RevList,
+        curr_list: RevList,
         options: Optional[dict] = None,
-    ) -> RevStatusListResult:
+    ) -> RevListResult:
         """Update a revocation list on the registry."""
         raise NotImplementedError()

--- a/aries_cloudagent/anoncreds/default/did_web/registry.py
+++ b/aries_cloudagent/anoncreds/default/did_web/registry.py
@@ -8,11 +8,11 @@ from ...base import BaseAnonCredsRegistrar, BaseAnonCredsResolver
 from ...models.anoncreds_cred_def import CredDef, CredDefResult, GetCredDefResult
 from ...models.anoncreds_revocation import (
     AnonCredsRegistryGetRevocationRegistryDefinition,
-    GetRevStatusListResult,
+    GetRevListResult,
     RevRegDef,
     RevRegDefResult,
-    RevStatusList,
-    RevStatusListResult,
+    RevList,
+    RevListResult,
 )
 from ...models.anoncreds_schema import AnonCredsSchema, GetSchemaResult, SchemaResult
 
@@ -78,29 +78,29 @@ class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         """Register a revocation registry definition on the registry."""
         raise NotImplementedError()
 
-    async def get_revocation_status_list(
+    async def get_revocation_list(
         self, profile: Profile, revocation_registry_id: str, timestamp: int
-    ) -> GetRevStatusListResult:
+    ) -> GetRevListResult:
         """Get a revocation list from the registry."""
         raise NotImplementedError()
 
-    async def register_revocation_status_list(
+    async def register_revocation_list(
         self,
         profile: Profile,
         rev_reg_def: RevRegDef,
-        rev_status_list: RevStatusList,
+        rev_list: RevList,
         options: Optional[dict] = None,
-    ) -> RevStatusListResult:
+    ) -> RevListResult:
         """Register a revocation list on the registry."""
         raise NotImplementedError()
 
-    async def update_revocation_status_list(
+    async def update_revocation_list(
         self,
         profile: Profile,
         rev_reg_def: RevRegDef,
-        prev_status_list: RevStatusList,
-        curr_status_list: RevStatusList,
+        prev_list: RevList,
+        curr_list: RevList,
         options: Optional[dict] = None,
-    ) -> RevStatusListResult:
+    ) -> RevListResult:
         """Update a revocation list on the registry."""
         raise NotImplementedError()

--- a/aries_cloudagent/anoncreds/holder.py
+++ b/aries_cloudagent/anoncreds/holder.py
@@ -559,7 +559,7 @@ class AnonCredsHolder:
         self,
         cred_rev_id: str,
         rev_reg_def: dict,
-        rev_status_list: dict,
+        rev_list: dict,
         tails_file_path: str,
     ) -> str:
         """
@@ -581,7 +581,7 @@ class AnonCredsHolder:
                 None,
                 CredentialRevocationState.create,
                 rev_reg_def,
-                rev_status_list,
+                rev_list,
                 int(cred_rev_id),
                 tails_file_path,
             )

--- a/aries_cloudagent/anoncreds/models/anoncreds_revocation.py
+++ b/aries_cloudagent/anoncreds/models/anoncreds_revocation.py
@@ -271,11 +271,11 @@ class AnonCredsRegistryGetRevocationRegistryDefinitionsSchema(BaseModelSchema):
     )
 
 
-class RevStatusList(BaseModel):
-    """RevStatusList."""
+class RevList(BaseModel):
+    """RevList."""
 
     class Meta:
-        """RevStatusList metadata."""
+        """RevList metadata."""
 
         schema_class = "AnonCredsRevocationListSchema"
 
@@ -296,22 +296,22 @@ class RevStatusList(BaseModel):
         self.timestamp = timestamp
 
     @classmethod
-    def from_native(cls, rev_status_list: RevocationStatusList):
-        """Convert from native revocation status list."""
-        return cls.deserialize(rev_status_list.to_json())
+    def from_native(cls, rev_list: RevocationStatusList):
+        """Convert from native revocation list."""
+        return cls.deserialize(rev_list.to_json())
 
     def to_native(self):
-        """Convert to native revocation status list."""
+        """Convert to native revocation list."""
         return RevocationStatusList.load(self.serialize())
 
 
-class RevStatusListSchema(BaseModelSchema):
-    """RevStatusListSchema."""
+class RevListSchema(BaseModelSchema):
+    """RevListSchema."""
 
     class Meta:
-        """RevStatusListSchema metadata."""
+        """RevListSchema metadata."""
 
-        model_class = RevStatusList
+        model_class = RevList
         unknown = EXCLUDE
 
     issuer_id = fields.Str(
@@ -329,8 +329,8 @@ class RevStatusListSchema(BaseModelSchema):
     timestamp = fields.Int()
 
 
-class RevStatusListState(BaseModel):
-    """RevStatusListState."""
+class RevListState(BaseModel):
+    """RevListState."""
 
     STATE_FINISHED = "finished"
     STATE_FAILED = "failed"
@@ -338,97 +338,95 @@ class RevStatusListState(BaseModel):
     STATE_WAIT = "wait"
 
     class Meta:
-        """RevStatusListState metadata."""
+        """RevListState metadata."""
 
-        schema_class = "RevStatusListStateSchema"
+        schema_class = "RevListStateSchema"
 
     def __init__(
         self,
         state: str,
-        revocation_status_list: RevStatusList,
+        revocation_list: RevList,
     ):
         self.state = state
-        self.revocation_status_list = revocation_status_list
+        self.revocation_list = revocation_list
 
 
-class RevStatusListStateSchema(BaseModelSchema):
-    """RevStatusListStateSchema."""
+class RevListStateSchema(BaseModelSchema):
+    """RevListStateSchema."""
 
     class Meta:
-        """RevStatusListStateSchema metadata."""
+        """RevListStateSchema metadata."""
 
-        model_class = RevStatusListState
+        model_class = RevListState
         unknown = EXCLUDE
 
     state = fields.Str(
         validate=OneOf(
             [
-                RevStatusListState.STATE_FINISHED,
-                RevStatusListState.STATE_FAILED,
-                RevStatusListState.STATE_ACTION,
-                RevStatusListState.STATE_WAIT,
+                RevListState.STATE_FINISHED,
+                RevListState.STATE_FAILED,
+                RevListState.STATE_ACTION,
+                RevListState.STATE_WAIT,
             ]
         )
     )
-    revocation_status_list = fields.Nested(
-        RevStatusListSchema(), description="revocation list"
-    )
+    revocation_list = fields.Nested(RevListSchema(), description="revocation list")
 
 
-class RevStatusListResult(BaseModel):
+class RevListResult(BaseModel):
     """Cred def result."""
 
     class Meta:
-        """RevStatusListResult metadata."""
+        """RevListResult metadata."""
 
-        schema_class = "RevStatusListResultSchema"
+        schema_class = "RevListResultSchema"
 
     def __init__(
         self,
         job_id: Optional[str],
-        revocation_status_list_state: RevStatusListState,
+        revocation_list_state: RevListState,
         registration_metadata: dict,
-        revocation_status_list_metadata: dict,
+        revocation_list_metadata: dict,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.job_id = job_id
-        self.revocation_status_list_state = revocation_status_list_state
+        self.revocations_list_state = revocation_list_state
         self.registration_metadata = registration_metadata
-        self.revocation_status_list_metadata = revocation_status_list_metadata
+        self.revocation_list_metadata = revocation_list_metadata
 
     @property
     def rev_reg_def_id(self):
-        return self.revocation_status_list_state.revocation_status_list_id
+        return self.revocation_list_state.revocation_list_id
 
 
-class RevStatusListResultSchema(BaseModelSchema):
+class RevListResultSchema(BaseModelSchema):
     """Cred def result schema."""
 
     class Meta:
-        """RevStatusListResultSchema metadata."""
+        """RevListResultSchema metadata."""
 
-        model_class = RevStatusListResult
+        model_class = RevListResult
         unknown = EXCLUDE
 
     job_id = fields.Str()
-    revocation_status_list_state = fields.Nested(RevStatusListStateSchema())
+    revocation_list_state = fields.Nested(RevListStateSchema())
     registration_metadata = fields.Dict()
-    # For indy, revocation_status_list_metadata will contain the seqNo
-    revocation_status_list_metadata = fields.Dict()
+    # For indy, revocation_list_metadata will contain the seqNo
+    revocation_list_metadata = fields.Dict()
 
 
-class GetRevStatusListResult(BaseModel):
-    """GetRevStatusListResult"""
+class GetRevListResult(BaseModel):
+    """GetRevListResult"""
 
     class Meta:
-        """GetRevStatusListResult metadata."""
+        """GetRevListResult metadata."""
 
-        schema_class = "GetRevStatusListResultSchema"
+        schema_class = "GetRevListResultSchema"
 
     def __init__(
         self,
-        revocation_list: RevStatusList,
+        revocation_list: RevList,
         resolution_metadata: Dict[str, Any],
         revocation_registry_metadata: Dict[str, Any],
         **kwargs,
@@ -439,15 +437,15 @@ class GetRevStatusListResult(BaseModel):
         self.revocation_registry_metadata = revocation_registry_metadata
 
 
-class GetRevStatusListResultSchema(BaseModelSchema):
-    """GetRevStatusListResultSchema"""
+class GetRevListResultSchema(BaseModelSchema):
+    """GetRevListResultSchema"""
 
     class Meta:
-        """GetRevStatusListResultSchema metadata."""
+        """GetRevListResultSchema metadata."""
 
-        model_class = GetRevStatusListResult
+        model_class = GetRevListResult
         unknown = EXCLUDE
 
-    revocation_list = fields.Nested(RevStatusListSchema)
+    revocation_list = fields.Nested(RevListSchema)
     resolution_metadata = fields.Str()
     revocation_registry_metadata = fields.Dict()

--- a/aries_cloudagent/anoncreds/registry.py
+++ b/aries_cloudagent/anoncreds/registry.py
@@ -10,12 +10,12 @@ from .models.anoncreds_cred_def import (
     GetCredDefResult,
 )
 from .models.anoncreds_revocation import (
-    GetRevStatusListResult,
+    GetRevListResult,
     AnonCredsRegistryGetRevocationRegistryDefinition,
     RevRegDef,
     RevRegDefResult,
-    RevStatusList,
-    RevStatusListResult,
+    RevList,
+    RevListResult,
 )
 from .models.anoncreds_schema import AnonCredsSchema, GetSchemaResult, SchemaResult
 from .base import (
@@ -140,38 +140,38 @@ class AnonCredsRegistry:
             profile, revocation_registry_definition, options
         )
 
-    async def get_revocation_status_list(
+    async def get_revocation_list(
         self, profile: Profile, revocation_registry_id: str, timestamp: int
-    ) -> GetRevStatusListResult:
+    ) -> GetRevListResult:
         """Get a revocation list from the registry."""
         resolver = await self._resolver_for_identifier(revocation_registry_id)
-        return await resolver.get_revocation_status_list(
+        return await resolver.get_revocation_list(
             profile, revocation_registry_id, timestamp
         )
 
-    async def register_revocation_status_list(
+    async def register_revocation_list(
         self,
         profile: Profile,
         rev_reg_def: RevRegDef,
-        rev_status_list: RevStatusList,
+        rev_list: RevList,
         options: Optional[dict] = None,
-    ) -> RevStatusListResult:
+    ) -> RevListResult:
         """Register a revocation list on the registry."""
-        registrar = await self._registrar_for_identifier(rev_status_list.issuer_id)
-        return await registrar.register_revocation_status_list(
-            profile, rev_reg_def, rev_status_list, options
+        registrar = await self._registrar_for_identifier(rev_list.issuer_id)
+        return await registrar.register_revocation_list(
+            profile, rev_reg_def, rev_list, options
         )
 
-    async def update_revocation_status_list(
+    async def update_revocation_list(
         self,
         profile: Profile,
         rev_reg_def: RevRegDef,
-        prev_status_list: RevStatusList,
-        curr_status_list: RevStatusList,
+        prev_list: RevList,
+        curr_list: RevList,
         options: Optional[dict] = None,
-    ) -> RevStatusListResult:
+    ) -> RevListResult:
         """Update a revocation list on the registry."""
-        registrar = await self._registrar_for_identifier(curr_status_list.issuer_id)
-        return await registrar.update_revocation_status_list(
-            profile, rev_reg_def, prev_status_list, curr_status_list, options
+        registrar = await self._registrar_for_identifier(curr_list.issuer_id)
+        return await registrar.update_revocation_list(
+            profile, rev_reg_def, prev_list, curr_list, options
         )

--- a/aries_cloudagent/anoncreds/verifier.py
+++ b/aries_cloudagent/anoncreds/verifier.py
@@ -380,14 +380,14 @@ class AnonCredsVerifier:
         self,
         identifiers: list,
     ) -> Tuple[dict, dict, dict, dict]:
-        """Return schemas, cred_defs, rev_reg_defs, rev_status_lists."""
+        """Return schemas, cred_defs, rev_reg_defs, rev_lists."""
         schema_ids = []
         cred_def_ids = []
 
         schemas = {}
         cred_defs = {}
         rev_reg_defs = {}
-        rev_status_lists = {}
+        rev_lists = {}
 
         for identifier in identifiers:
             schema_ids.append(identifier["schema_id"])
@@ -417,25 +417,25 @@ class AnonCredsVerifier:
                     ).revocation_registry.serialize()
 
                 if identifier.get("timestamp"):
-                    rev_status_lists.setdefault(identifier["rev_reg_id"], {})
+                    rev_lists.setdefault(identifier["rev_reg_id"], {})
 
                     if (
                         identifier["timestamp"]
-                        not in rev_status_lists[identifier["rev_reg_id"]]
+                        not in rev_lists[identifier["rev_reg_id"]]
                     ):
-                        result = await anoncreds_registry.get_revocation_status_list(
+                        result = await anoncreds_registry.get_revocation_list(
                             self.profile,
                             identifier["rev_reg_id"],
                             identifier["timestamp"],
                         )
-                        rev_status_lists[identifier["rev_reg_id"]][
+                        rev_lists[identifier["rev_reg_id"]][
                             identifier["timestamp"]
                         ] = result.revocation_list.serialize()
         return (
             schemas,
             cred_defs,
             rev_reg_defs,
-            rev_status_lists,
+            rev_lists,
         )
 
     async def verify_presentation(
@@ -445,7 +445,7 @@ class AnonCredsVerifier:
         schemas,
         credential_definitions,
         rev_reg_defs,
-        rev_status_lists,
+        rev_lists,
     ) -> Tuple[bool, list]:
         """
         Verify a presentation.
@@ -484,7 +484,7 @@ class AnonCredsVerifier:
                 schemas,
                 credential_definitions,
                 rev_reg_defs,
-                rev_status_lists,
+                rev_lists,
             )
         except AnoncredsError as err:
             s = str(err)

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -415,7 +415,7 @@ class PresentationManager:
             schemas,
             cred_defs,
             rev_reg_defs,
-            rev_status_lists,
+            rev_lists,
         ) = await verifier.process_pres_identifiers(indy_proof["identifiers"])
 
         verifier = self._profile.inject(AnonCredsVerifier)
@@ -427,7 +427,7 @@ class PresentationManager:
             schemas,
             cred_defs,
             rev_reg_defs,
-            rev_status_lists,
+            rev_lists,
         )
         presentation_exchange_record.verified = json.dumps(verified_bool)
         presentation_exchange_record.verified_msgs = list(set(verified_msgs))

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/indy/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/indy/handler.py
@@ -326,7 +326,7 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
             schemas,
             cred_defs,
             rev_reg_defs,
-            rev_status_lists,
+            rev_lists,
         ) = await verifier.process_pres_identifiers(indy_proof["identifiers"])
 
         verifier = AnonCredsVerifier(self._profile)
@@ -337,7 +337,7 @@ class IndyPresExchangeHandler(V20PresFormatHandler):
             schemas,
             cred_defs,
             rev_reg_defs,
-            rev_status_lists,
+            rev_lists,
         )
         pres_ex_record.verified = json.dumps(verified)
         pres_ex_record.verified_msgs = list(set(verified_msgs))

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -293,8 +293,8 @@ class CredRevRecordDetailsResultSchema(OpenAPISchema):
 class CredRevIndyRecordsResultSchema(OpenAPISchema):
     """Result schema for revoc reg delta."""
 
-    rev_status_list = fields.Dict(
-        description="revocation status list",
+    rev_list = fields.Dict(
+        description="revocation list",
     )
 
 
@@ -725,7 +725,7 @@ async def get_rev_reg_issued(request: web.BaseRequest):
 )
 @match_info_schema(RevRegIdMatchInfoSchema())
 @response_schema(CredRevIndyRecordsResultSchema(), 200, description="")
-async def get_rev_status_list(request: web.BaseRequest):
+async def get_rev_list(request: web.BaseRequest):
     """
     Request handler to get details of revoked credentials from ledger.
 
@@ -741,13 +741,13 @@ async def get_rev_status_list(request: web.BaseRequest):
     rev_reg_id = request.match_info["rev_reg_id"]
 
     anoncreds_registry = context.inject(AnonCredsRegistry)
-    rev_status_list = await anoncreds_registry.get_revocation_status_list(
+    rev_list = await anoncreds_registry.get_revocation_list(
         context.profile, rev_reg_id, int(time())
     )
 
     return web.json_response(
         {
-            "rev_status_list": rev_status_list,
+            "rev_list": rev_list,
         }
     )
 
@@ -842,7 +842,7 @@ async def update_rev_reg_revoked_state(request: web.BaseRequest):
 
 @docs(
     tags=["revocation"],
-    summary="Get credential revocation status",
+    summary="Get credential revocation",
 )
 @querystring_schema(CredRevRecordQueryStringSchema())
 @response_schema(CredRevRecordResultSchema(), 200, description="")
@@ -1571,7 +1571,7 @@ async def register(app: web.Application):
             ),
             web.get(
                 "/revocation/registry/{rev_reg_id}/issued/indy_recs",
-                get_rev_status_list,
+                get_rev_list,
                 allow_head=False,
             ),
             web.post("/revocation/create-registry", create_rev_reg),


### PR DESCRIPTION
This PR updates "revocation status list" to "revocation list." This change seeks to avoid confusion with the W3C VC Spec concept of Credential Status Lists.