### PR TITLE
Refactor/anoncreds revocation move logic

### DIFF
--- a/aries_cloudagent/anoncreds/routes.py
+++ b/aries_cloudagent/anoncreds/routes.py
@@ -381,7 +381,14 @@ async def rev_reg_def_post(request: web.BaseRequest):
         )
     except RevocationNotSupportedError as e:
         raise web.HTTPBadRequest(reason=e.message) from e
-    result = await shield(issuer_rev_reg_rec.create_and_register_def(context.profile))
+    issuer = AnonCredsIssuer(context.profile)
+    result = await shield(
+        issuer.create_and_register_revocation_registry_definition(
+            context.profile,
+            issuer_rev_reg_rec,
+            options,
+        )
+    )
 
     return web.json_response(result.serialize())
 

--- a/aries_cloudagent/anoncreds/routes.py
+++ b/aries_cloudagent/anoncreds/routes.py
@@ -381,7 +381,6 @@ async def rev_reg_def_post(request: web.BaseRequest):
         )
     except RevocationNotSupportedError as e:
         raise web.HTTPBadRequest(reason=e.message) from e
-    issuer = AnonCredsIssuer(context.profile)
     result = await shield(
         issuer.create_and_register_revocation_registry_definition(
             context.profile,

--- a/aries_cloudagent/anoncreds/routes.py
+++ b/aries_cloudagent/anoncreds/routes.py
@@ -424,9 +424,10 @@ async def rev_list_post(request: web.BaseRequest):
 
     try:
         revoc = AnonCredsRevocation(context.profile)
-        rev_reg = await revoc.get_issuer_rev_reg_record(rev_reg_def_id)
-        result = await rev_reg.create_and_register_list(
-            context.profile,
+        rev_reg_record = await revoc.get_issuer_rev_reg_record(rev_reg_def_id)
+        issuer = AnonCredsIssuer(context.profile)
+        result = await issuer.create_and_register_revocation_list(
+            rev_reg_record,
             options,
         )
         LOGGER.debug("published revocation list for: %s", rev_reg_def_id)


### PR DESCRIPTION
This PR updates the `/anoncreds/revocation-registry-definition` and `/anoncreds/revocation-list` endpoints to call corresponding methods on `AnonCredsIssuer` rather than `IssuerRevRegRecord.`