### PR TITLE
Issue revocable creds using anoncreds interface

### DIFF
--- a/anoncreds_test.py
+++ b/anoncreds_test.py
@@ -64,6 +64,12 @@ async def main():
                 "maxCredNum": 10,
             },
         )
+        rev_reg_def_id = rev_reg_def["revocation_registry_definition_state"][
+            "revocation_registry_definition_id"
+        ]
+        tails = await alice.put(
+            f"/anoncreds/registry/{rev_reg_def_id}/tails-file",
+        )
         rev_status_list = await alice.post(
             "/anoncreds/revocation-list",
             json={

--- a/aries_cloudagent/anoncreds/base.py
+++ b/aries_cloudagent/anoncreds/base.py
@@ -12,7 +12,7 @@ from .models.anoncreds_cred_def import (
 )
 from .models.anoncreds_revocation import (
     GetRevListResult,
-    AnonCredsRegistryGetRevocationRegistryDefinition,
+    GetRevRegDefResult,
     RevRegDef,
     RevRegDefResult,
     RevList,
@@ -115,7 +115,7 @@ class BaseAnonCredsResolver(BaseAnonCredsHandler):
     @abstractmethod
     async def get_revocation_registry_definition(
         self, profile: Profile, revocation_registry_id: str
-    ) -> AnonCredsRegistryGetRevocationRegistryDefinition:
+    ) -> GetRevRegDefResult:
         """Get a revocation registry definition from the registry."""
 
     @abstractmethod

--- a/aries_cloudagent/anoncreds/default/did_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/did_indy/registry.py
@@ -12,7 +12,7 @@ from ...models.anoncreds_cred_def import (
 )
 from ...models.anoncreds_revocation import (
     GetRevListResult,
-    AnonCredsRegistryGetRevocationRegistryDefinition,
+    GetRevRegDefResult,
     RevRegDef,
     RevRegDefResult,
     RevList,
@@ -70,7 +70,7 @@ class DIDIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
 
     async def get_revocation_registry_definition(
         self, profile: Profile, revocation_registry_id: str
-    ) -> AnonCredsRegistryGetRevocationRegistryDefinition:
+    ) -> GetRevRegDefResult:
         """Get a revocation registry definition from the registry."""
         raise NotImplementedError()
 

--- a/aries_cloudagent/anoncreds/default/did_web/registry.py
+++ b/aries_cloudagent/anoncreds/default/did_web/registry.py
@@ -4,26 +4,15 @@ from typing import Optional, Pattern
 
 from ....config.injection_context import InjectionContext
 from ....core.profile import Profile
-from ...models.anoncreds_cred_def import (
-    GetCredDefResult,
-)
-from ...models.anoncreds_revocation import (
-    GetRevListResult,
-    AnonCredsRegistryGetRevocationRegistryDefinition,
-    RevRegDef,
-    RevList,
-    RevListResult,
-)
-from ...models.anoncreds_schema import GetSchemaResult
 from ...base import BaseAnonCredsRegistrar, BaseAnonCredsResolver
 from ...models.anoncreds_cred_def import CredDef, CredDefResult, GetCredDefResult
 from ...models.anoncreds_revocation import (
-    AnonCredsRegistryGetRevocationRegistryDefinition,
     GetRevListResult,
-    RevRegDef,
-    RevRegDefResult,
+    GetRevRegDefResult,
     RevList,
     RevListResult,
+    RevRegDef,
+    RevRegDefResult,
 )
 from ...models.anoncreds_schema import AnonCredsSchema, GetSchemaResult, SchemaResult
 
@@ -76,7 +65,7 @@ class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
 
     async def get_revocation_registry_definition(
         self, profile: Profile, revocation_registry_id: str
-    ) -> AnonCredsRegistryGetRevocationRegistryDefinition:
+    ) -> GetRevRegDefResult:
         """Get a revocation registry definition from the registry."""
         raise NotImplementedError()
 

--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -41,7 +41,7 @@ from ...models.anoncreds_cred_def import (
     GetCredDefResult,
 )
 from ...models.anoncreds_revocation import (
-    AnonCredsRegistryGetRevocationRegistryDefinition,
+    GetRevRegDefResult,
     GetRevListResult,
     RevRegDef,
     RevRegDefResult,
@@ -357,7 +357,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
 
     async def get_revocation_registry_definition(
         self, profile: Profile, rev_reg_def_id: str
-    ) -> AnonCredsRegistryGetRevocationRegistryDefinition:
+    ) -> GetRevRegDefResult:
         """Get a revocation registry definition from the registry."""
 
         try:

--- a/aries_cloudagent/anoncreds/holder.py
+++ b/aries_cloudagent/anoncreds/holder.py
@@ -85,7 +85,9 @@ class AnonCredsHolder:
                     raise AnonCredsHolderError("Error fetching master secret") from err
                 if record:
                     try:
-                        secret = record.raw_value
+                        # TODO should be able to use raw_value but memoryview
+                        # isn't accepted by cred.process
+                        secret = record.value.decode("ascii")
                     except AnoncredsError as err:
                         raise AnonCredsHolderError(
                             "Error loading master secret"

--- a/aries_cloudagent/anoncreds/issuer.py
+++ b/aries_cloudagent/anoncreds/issuer.py
@@ -646,6 +646,8 @@ class AnonCredsIssuer:
                 f"Tails file for rev reg for {rev_reg_def.cred_def_id} "
                 "uploaded to wrong location: {result}"
             )
+        # TODO: do we need to set uri? something like..
+        # await self.set_tails_file_public_uri(profile, result)
 
     async def update_revocation_registry_definition_state(
         self, rev_reg_def_id: str, state: str

--- a/aries_cloudagent/anoncreds/models/anoncreds_revocation.py
+++ b/aries_cloudagent/anoncreds/models/anoncreds_revocation.py
@@ -205,13 +205,13 @@ class RevRegDefResultSchema(BaseModelSchema):
     revocation_registry_definition_metadata = fields.Dict()
 
 
-class AnonCredsRegistryGetRevocationRegistryDefinition(BaseModel):
-    """AnonCredsRegistryGetRevocationRegistryDefinition"""
+class GetRevRegDefResult(BaseModel):
+    """GetRevRegDefResult"""
 
     class Meta:
-        """AnonCredsRegistryGetRevocationRegistryDefinition metadata."""
+        """GetRevRegDefResult metadata."""
 
-        schema_class = "AnonCredsRegistryGetRevocationRegistryDefinitionSchema"
+        schema_class = "GetRevRegDefResultSchema"
 
     def __init__(
         self,
@@ -228,11 +228,11 @@ class AnonCredsRegistryGetRevocationRegistryDefinition(BaseModel):
         self.revocation_registry_metadata = revocation_registry_metadata
 
 
-class AnonCredsRegistryGetRevocationRegistryDefinitionSchema(BaseModelSchema):
+class GetRevRegDefResultSchema(BaseModelSchema):
     class Meta:
-        """AnonCredsRegistryGetRevocationRegistryDefinitionSchema metadata."""
+        """GetRevRegDefResultSchema metadata."""
 
-        model_class = AnonCredsRegistryGetRevocationRegistryDefinition
+        model_class = GetRevRegDefResult
         unknown = EXCLUDE
 
     revocation_registry = fields.Nested(RevRegDefSchema())

--- a/aries_cloudagent/anoncreds/registry.py
+++ b/aries_cloudagent/anoncreds/registry.py
@@ -11,7 +11,7 @@ from .models.anoncreds_cred_def import (
 )
 from .models.anoncreds_revocation import (
     GetRevListResult,
-    AnonCredsRegistryGetRevocationRegistryDefinition,
+    GetRevRegDefResult,
     RevRegDef,
     RevRegDefResult,
     RevList,
@@ -119,7 +119,7 @@ class AnonCredsRegistry:
 
     async def get_revocation_registry_definition(
         self, profile: Profile, revocation_registry_id: str
-    ) -> AnonCredsRegistryGetRevocationRegistryDefinition:
+    ) -> GetRevRegDefResult:
         """Get a revocation registry definition from the registry."""
         resolver = await self._resolver_for_identifier(revocation_registry_id)
         return await resolver.get_revocation_registry_definition(

--- a/aries_cloudagent/anoncreds/routes.py
+++ b/aries_cloudagent/anoncreds/routes.py
@@ -21,7 +21,6 @@ from aries_cloudagent.revocation.routes import (
 from ..admin.request_context import AdminRequestContext
 from ..messaging.models.openapi import OpenAPISchema
 from ..messaging.valid import UUIDFour
-from ..revocation.anoncreds import AnonCredsRevocation
 from ..revocation.error import RevocationNotSupportedError
 from ..storage.error import StorageNotFoundError
 from .issuer import AnonCredsIssuer, AnonCredsIssuerError
@@ -429,12 +428,13 @@ async def rev_list_post(request: web.BaseRequest):
     rev_reg_def_id = body.get("revRegDefId")
     options = body.get("options")
 
+    issuer = AnonCredsIssuer(context.profile)
     try:
-        revoc = AnonCredsRevocation(context.profile)
-        rev_reg = await revoc.get_issuer_rev_reg_record(rev_reg_def_id)
-        result = await rev_reg.create_and_register_list(
-            context.profile,
-            options,
+        result = await shield(
+            issuer.create_and_register_revocation_list(
+                rev_reg_def_id,
+                options,
+            )
         )
         LOGGER.debug("published revocation list for: %s", rev_reg_def_id)
 

--- a/aries_cloudagent/anoncreds/routes.py
+++ b/aries_cloudagent/anoncreds/routes.py
@@ -27,7 +27,6 @@ from ..storage.error import StorageNotFoundError
 from .issuer import AnonCredsIssuer, AnonCredsIssuerError
 from .models.anoncreds_cred_def import CredDefResultSchema, GetCredDefResultSchema
 from .models.anoncreds_revocation import (
-    GetRevRegDefResult,
     RevRegDef,
     RevRegDefResultSchema,
     RevListResultSchema,
@@ -467,12 +466,12 @@ async def upload_tails_file(request: web.BaseRequest):
     rev_reg_id = request.match_info["rev_reg_id"]
     try:
         issuer = AnonCredsIssuer(profile)
-        get_rev_reg_def: GetRevRegDefResult = (
+        rev_reg_def_result = (
             await anoncreds_registry.get_revocation_registry_definition(
                 profile, rev_reg_id
             )
         )
-        rev_reg_def: RevRegDef = get_rev_reg_def.revocation_registry
+        rev_reg_def: RevRegDef = rev_reg_def_result.revocation_registry
     # TODO: Should we check if tails file exists
     except StorageNotFoundError as err:  # TODO: update error
         raise web.HTTPNotFound(reason=err.roll_up) from err

--- a/aries_cloudagent/anoncreds/routes.py
+++ b/aries_cloudagent/anoncreds/routes.py
@@ -27,7 +27,7 @@ from ..storage.error import StorageNotFoundError
 from .issuer import AnonCredsIssuer, AnonCredsIssuerError
 from .models.anoncreds_cred_def import CredDefResultSchema, GetCredDefResultSchema
 from .models.anoncreds_revocation import (
-    AnonCredsRegistryGetRevocationRegistryDefinition,
+    GetRevRegDefResult,
     RevRegDef,
     RevRegDefResultSchema,
     RevListResultSchema,
@@ -467,7 +467,7 @@ async def upload_tails_file(request: web.BaseRequest):
     rev_reg_id = request.match_info["rev_reg_id"]
     try:
         issuer = AnonCredsIssuer(profile)
-        get_rev_reg_def: AnonCredsRegistryGetRevocationRegistryDefinition = (
+        get_rev_reg_def: GetRevRegDefResult = (
             await anoncreds_registry.get_revocation_registry_definition(
                 profile, rev_reg_id
             )
@@ -505,7 +505,7 @@ async def register(app: web.Application):
             ),
             web.post("/anoncreds/revocation-registry-definition", rev_reg_def_post),
             web.post("/anoncreds/revocation-list", rev_list_post),
-            web.put("/revocation/registry/{rev_reg_id}/tails-file", upload_tails_file),
+            web.put("/anoncreds/registry/{rev_reg_id}/tails-file", upload_tails_file),
         ]
     )
 

--- a/aries_cloudagent/anoncreds/routes.py
+++ b/aries_cloudagent/anoncreds/routes.py
@@ -477,11 +477,7 @@ async def upload_tails_file(request: web.BaseRequest):
     except StorageNotFoundError as err:  # TODO: update error
         raise web.HTTPNotFound(reason=err.roll_up) from err
     try:
-        await issuer.upload_tails_file(
-            rev_reg_def.value.tails_hash,
-            rev_reg_def.cred_def_id,
-            rev_reg_def.value.tails_location,
-        )
+        await issuer.upload_tails_file(rev_reg_def)
     except AnonCredsIssuerError as e:
         raise web.HTTPInternalServerError(reason=str(e)) from e
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
@@ -1,6 +1,5 @@
 """V2.0 issue-credential indy credential format handler."""
 
-import asyncio
 import json
 import logging
 from typing import Mapping, Tuple
@@ -11,7 +10,6 @@ from ......anoncreds.registry import AnonCredsRegistry
 from ......anoncreds.holder import AnonCredsHolder, AnonCredsHolderError
 from ......anoncreds.issuer import (
     AnonCredsIssuer,
-    AnonCredsIssuerRevocationRegistryFullError,
 )
 from ......anoncreds.models.cred import IndyCredentialSchema
 from ......anoncreds.models.cred_abstract import IndyCredAbstractSchema
@@ -28,9 +26,7 @@ from ......messaging.credential_definitions.util import (
 )
 from ......messaging.decorators.attach_decorator import AttachDecorator
 from ......multitenant.base import BaseMultitenantManager
-from ......revocation.anoncreds import AnonCredsRevocation
 from ......revocation.models.issuer_cred_rev_record import IssuerCredRevRecord
-from ......revocation.models.revocation_registry import RevocationRegistry
 from ......storage.base import BaseStorage
 from ...message_types import (
     ATTACHMENT_FORMAT,
@@ -327,83 +323,35 @@ class IndyCredFormatHandler(V20CredFormatHandler):
         cred_values = cred_ex_record.cred_offer.credential_preview.attr_dict(
             decode=False
         )
-        schema_id = cred_offer["schema_id"]
-        cred_def_id = cred_offer["cred_def_id"]
 
         issuer = AnonCredsIssuer(self.profile)
 
-        revocable = await issuer.cred_def_supports_revocation(cred_def_id)
-        result = None
-
-        for attempt in range(max(retries, 1)):
-            if attempt > 0:
-                LOGGER.info(
-                    "Waiting 2s before retrying credential issuance for cred def '%s'",
-                    cred_def_id,
-                )
-                await asyncio.sleep(2)
-
-            if revocable:
-                # TODO make this go through the anoncreds interface
-                revoc = AnonCredsRevocation(self.profile)
-                registry_info = await revoc.get_or_create_active_registry(cred_def_id)
-                if not registry_info:
-                    continue
-                del revoc
-                issuer_rev_reg, rev_reg = registry_info
-                rev_reg_id = issuer_rev_reg.revoc_reg_id
-                tails_path = rev_reg.tails_local_path
-            else:
-                rev_reg_id = None
-                tails_path = None
-
-            try:
-                (cred_json, cred_rev_id) = await issuer.create_credential(
-                    schema_id,
-                    cred_offer,
-                    cred_request,
-                    cred_values,
-                    rev_reg_id,
-                    tails_path,
-                )
-            except AnonCredsIssuerRevocationRegistryFullError:
-                # unlucky, another instance filled the registry first
-                continue
-
-            if revocable and rev_reg.max_creds <= int(cred_rev_id):
-                revoc = AnonCredsRevocation(self.profile)
-                await revoc.handle_full_registry(rev_reg_id)
-                del revoc
-
-            result = self.get_format_data(CRED_20_ISSUE, json.loads(cred_json))
-            break
-
-        if not result:
-            raise V20CredFormatError(
-                f"Cred def '{cred_def_id}' has no active revocation registry"
-            )
+        cred_json, cred_rev_id, rev_reg_def_id = await issuer.create_credential(
+            cred_offer, cred_request, cred_values
+        )
+        result = self.get_format_data(CRED_20_ISSUE, json.loads(cred_json))
 
         async with self._profile.transaction() as txn:
             detail_record = V20CredExRecordIndy(
                 cred_ex_id=cred_ex_record.cred_ex_id,
-                rev_reg_id=rev_reg_id,
+                rev_reg_id=rev_reg_def_id,
                 cred_rev_id=cred_rev_id,
             )
             await detail_record.save(txn, reason="v2.0 issue credential")
 
-            if revocable and cred_rev_id:
+            if cred_rev_id:
                 issuer_cr_rec = IssuerCredRevRecord(
                     state=IssuerCredRevRecord.STATE_ISSUED,
                     cred_ex_id=cred_ex_record.cred_ex_id,
                     cred_ex_version=IssuerCredRevRecord.VERSION_2,
-                    rev_reg_id=rev_reg_id,
+                    rev_reg_id=rev_reg_def_id,
                     cred_rev_id=cred_rev_id,
                 )
                 await issuer_cr_rec.save(
                     txn,
                     reason=(
                         "Created issuer cred rev record for "
-                        f"rev reg id {rev_reg_id}, index {cred_rev_id}"
+                        f"rev reg id {rev_reg_def_id}, index {cred_rev_id}"
                     ),
                 )
             await txn.commit()
@@ -435,7 +383,7 @@ class IndyCredFormatHandler(V20CredFormatHandler):
                     self.profile, cred["rev_reg_id"]
                 )
             )
-            rev_reg_def = rev_reg_def_result.revocation_registry.serialize()
+            rev_reg_def = rev_reg_def_result.revocation_registry
 
         holder = AnonCredsHolder(self.profile)
         cred_offer_message = cred_ex_record.cred_offer
@@ -444,8 +392,8 @@ class IndyCredFormatHandler(V20CredFormatHandler):
             mime_types = cred_offer_message.credential_preview.mime_types() or None
 
         if rev_reg_def:
-            rev_reg = RevocationRegistry.from_definition(rev_reg_def, True)
-            await rev_reg.get_or_fetch_local_tails_path()
+            issuer = AnonCredsIssuer(self.profile)
+            await issuer.get_or_fetch_local_tails_path(rev_reg_def)
         try:
             detail_record = await self.get_detail_record(cred_ex_record.cred_ex_id)
             if detail_record is None:
@@ -459,7 +407,7 @@ class IndyCredFormatHandler(V20CredFormatHandler):
                 detail_record.cred_request_metadata,
                 mime_types,
                 credential_id=cred_id,
-                rev_reg_def=rev_reg_def,
+                rev_reg_def=rev_reg_def.serialize() if rev_reg_def else None,
             )
 
             detail_record.cred_id_stored = cred_id_stored


### PR DESCRIPTION
This PR finishes off the full issuance flow using the generic anoncreds interface. Places where the original Indy-specific components were used have been replaced with generic calls, most of which happen in the `anoncreds/issuer.py` file. There is room for further refinement; `issuer.py` is now quite long and many of the methods are specific to revocation and some of those methods are actually used by both issuer and holder. This suggests a need for an `AnonCredsRevocation` component. This can be introduced in a follow up PR.

This PR supersedes #125. Those commits are included here and were necessary to complete the full issuance flow with revocation. (Thanks, @burdettadam)

This PR (currently) conflicts with #124; I believe we can simplify the revocation logic by eliminating the `IssuerRevRegRecord` and `RevocationRegistry` classes (both of which had questionable value and an overloading of responsibilities). This PR represents an "MVP" that does not make use of those classes. However, there may be cause to rework and reintroduce those classes still so I'm not ruling out the changes in #124 completely (which already goes a long way towards making those classes make a whole lot more sense -- thanks, @cjhowland).